### PR TITLE
Switch Metkit from sandbox to ecmwf/metkit

### DIFF
--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -12,6 +12,9 @@ on:
       metkit:
         required: false
         type: string
+      metkit_sha:
+        required: false
+        type: string
       atlas:
         required: false
         type: string
@@ -42,7 +45,7 @@ jobs:
     # needs: [eccodes, eckit]
     if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.metkit) }}
     name: metkit
-    uses: ecmwf-enterprise-sandbox/metkit/.github/workflows/reusable-ci-hpc.yml@upstream-ci-hpc
+    uses: ecmwf/metkit/.github/workflows/reusable-ci-hpc.yml@${{ inputs.metkit_sha }}
     with:
       metkit: ${{ inputs.metkit }}
       eckit: ${{ inputs.eckit }}

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -12,6 +12,9 @@ on:
       metkit:
         required: false
         type: string
+      metkit_sha:
+        required: false
+        type: string
       atlas:
         required: false
         type: string
@@ -42,8 +45,9 @@ jobs:
     # needs: [eccodes, eckit]
     if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.metkit) }}
     name: metkit
-    uses: ecmwf-enterprise-sandbox/metkit/.github/workflows/reusable-ci.yml@upstream-ci-self-hosted
+    uses: ecmwf/metkit/.github/workflows/reusable-ci.yml@${{ inputs.metkit_sha }}
     with:
+      metkit_sha: ${{ inputs.metkit_sha }}
       eccodes: ${{ inputs.eccodes }}
       eckit: ${{ inputs.eckit }}
     secrets: inherit


### PR DESCRIPTION
Comment out all other packages as they are not yet prepared.
Add `metkit_sha` input which is needed to specify correct `reusable-ci.yml` and `build-package` also expects separate sha input.