### PR TITLE
Create downstream of public packages

### DIFF
--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -18,12 +18,6 @@ on:
       atlas:
         required: false
         type: string
-      mir:
-        required: false
-        type: string
-      pgen:
-        required: false
-        type: string
 
 jobs:
   # eccodes:
@@ -60,31 +54,4 @@ jobs:
   #   with:
   #     atlas: ${{ inputs.atlas }}
   #     eckit: ${{ inputs.eckit }}
-  #   secrets: inherit
-
-  # mir:
-  #   needs: [metkit, atlas]
-  #   if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.mir) }}
-  #   name: mir
-  #   uses: ecmwf-enterprise-sandbox/mir/.github/workflows/reusable-ci-hpc.yml@upstream-ci-hpc
-  #   with:
-  #     mir: ${{ inputs.mir }}
-  #     eccodes: ${{ inputs.eccodes }}
-  #     eckit: ${{ inputs.eckit }}
-  #     metkit: ${{ inputs.metkit }}
-  #     atlas: ${{ inputs.atlas }}
-  #   secrets: inherit
-
-  # pgen:
-  #   needs: [mir]
-  #   if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.pgen) }}
-  #   name: pgen
-  #   uses: ecmwf-enterprise-sandbox/pgen/.github/workflows/reusable-ci-hpc.yml@upstream-ci-hpc
-  #   with:
-  #     pgen: ${{ inputs.pgen }}
-  #     eccodes: ${{ inputs.eccodes }}
-  #     eckit: ${{ inputs.eckit }}
-  #     metkit: ${{ inputs.metkit }}
-  #     atlas: ${{ inputs.atlas }}
-  #     mir: ${{ inputs.mir }}
   #   secrets: inherit

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -23,16 +23,16 @@ jobs:
   #   uses: ecmwf-enterprise-sandbox/eccodes/.github/workflows/reusable-ci-hpc.yml@upstream-ci-hpc
   #   secrets: inherit
 
-  # eckit:
-  #   name: eckit
-  #   if: ${{ inputs.eckit }}
-  #   uses: ecmwf-enterprise-sandbox/eckit/.github/workflows/reusable-ci-hpc.yml@upstream-ci-hpc
-  #   with:
-  #     eckit: ${{ inputs.eckit }}
-  #   secrets: inherit
+  eckit:
+    name: eckit
+    if: ${{ inputs.eckit }}
+    uses: ecmwf/eckit/.github/workflows/reusable-ci-hpc.yml@develop
+    with:
+      eckit: ${{ inputs.eckit }}
+    secrets: inherit
 
   metkit:
-    # needs: [eccodes, eckit]
+    needs: [eckit] # eccodes
     if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.metkit) }}
     name: metkit
     uses: ecmwf/metkit/.github/workflows/reusable-ci-hpc.yml@develop

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -12,9 +12,6 @@ on:
       metkit:
         required: false
         type: string
-      metkit_sha:
-        required: false
-        type: string
       atlas:
         required: false
         type: string
@@ -35,11 +32,10 @@ jobs:
   #   secrets: inherit
 
   metkit:
-    # needs eccodes and eckit to complete first, always() ensures that it will run regardless of whether they were successfull and at least one job in needs was successful, or the inputs.metkit is populated
     # needs: [eccodes, eckit]
     if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.metkit) }}
     name: metkit
-    uses: ecmwf/metkit/.github/workflows/reusable-ci-hpc.yml@${{ inputs.metkit_sha }}
+    uses: ecmwf/metkit/.github/workflows/reusable-ci-hpc.yml@develop
     with:
       metkit: ${{ inputs.metkit }}
       eckit: ${{ inputs.eckit }}

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -23,14 +23,14 @@ jobs:
   #   uses: ecmwf-enterprise-sandbox/eccodes/.github/workflows/reusable-ci.yml@upstream-ci-self-hosted
   #   secrets: inherit
 
-  # eckit:
-  #   name: eckit
-  #   if: ${{ inputs.eckit }}
-  #   uses: ecmwf-enterprise-sandbox/eckit/.github/workflows/reusable-ci.yml@upstream-ci-self-hosted
-  #   secrets: inherit
+  eckit:
+    name: eckit
+    if: ${{ inputs.eckit }}
+    uses: ecmwf/eckit/.github/workflows/reusable-ci.yml@develop
+    secrets: inherit
 
   metkit:
-    # needs: [eccodes, eckit]
+    needs: [eckit] # eccodes
     if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.metkit) }}
     name: metkit
     uses: ecmwf/metkit/.github/workflows/reusable-ci.yml@develop

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -12,9 +12,6 @@ on:
       metkit:
         required: false
         type: string
-      metkit_sha:
-        required: false
-        type: string
       atlas:
         required: false
         type: string
@@ -36,9 +33,9 @@ jobs:
     # needs: [eccodes, eckit]
     if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.metkit) }}
     name: metkit
-    uses: ecmwf/metkit/.github/workflows/reusable-ci.yml@${{ inputs.metkit_sha }}
+    uses: ecmwf/metkit/.github/workflows/reusable-ci.yml@develop
     with:
-      metkit_sha: ${{ inputs.metkit_sha }}
+      metkit: ${{ inputs.metkit }}
       eccodes: ${{ inputs.eccodes }}
       eckit: ${{ inputs.eckit }}
     secrets: inherit

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -18,12 +18,6 @@ on:
       atlas:
         required: false
         type: string
-      mir:
-        required: false
-        type: string
-      pgen:
-        required: false
-        type: string
     secrets:
       PAT:
         required: true
@@ -59,29 +53,4 @@ jobs:
   #   uses: ecmwf-enterprise-sandbox/atlas/.github/workflows/reusable-ci.yml@upstream-ci-self-hosted
   #   with:
   #     eckit: ${{ inputs.eckit }}
-  #   secrets: inherit
-
-  # mir:
-  #   needs: [metkit, atlas]
-  #   if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.mir) }}
-  #   name: mir
-  #   uses: ecmwf-enterprise-sandbox/mir/.github/workflows/reusable-ci.yml@upstream-ci-self-hosted
-  #   with:
-  #     eccodes: ${{ inputs.eccodes }}
-  #     eckit: ${{ inputs.eckit }}
-  #     metkit: ${{ inputs.metkit }}
-  #     atlas: ${{ inputs.atlas }}
-  #   secrets: inherit
-
-  # pgen:
-  #   needs: [mir]
-  #   if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.pgen) }}
-  #   name: pgen
-  #   uses: ecmwf-enterprise-sandbox/pgen/.github/workflows/reusable-ci.yml@upstream-ci-self-hosted
-  #   with:
-  #     eccodes: ${{ inputs.eccodes }}
-  #     eckit: ${{ inputs.eckit }}
-  #     metkit: ${{ inputs.metkit }}
-  #     atlas: ${{ inputs.atlas }}
-  #     mir: ${{ inputs.mir }}
   #   secrets: inherit

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -18,9 +18,6 @@ on:
       atlas:
         required: false
         type: string
-    secrets:
-      PAT:
-        required: true
 
 jobs:
   # eccodes:


### PR DESCRIPTION
Downstream CI contains only public packages.
Active ones are `metkit` and `eckit`.