### PR TITLE
Switch from reusable WFs to composite actions

### DIFF
--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -77,7 +77,7 @@ jobs:
     runs-on:
       [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@feature/hpc-action
+      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
         with:
           github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
           github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
@@ -95,7 +95,7 @@ jobs:
     runs-on:
       [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@feature/hpc-action
+      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
         with:
           github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
           github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
@@ -113,7 +113,7 @@ jobs:
     runs-on:
       [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@feature/hpc-action
+      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
         with:
           github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
           github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
@@ -134,7 +134,7 @@ jobs:
     runs-on:
       [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@feature/hpc-action
+      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
         with:
           github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
           github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
@@ -154,7 +154,7 @@ jobs:
     runs-on:
       [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@feature/hpc-action
+      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
         with:
           github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
           github_token: ${{ secrets.GH_REPO_READ_TOKEN }}

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -123,11 +123,21 @@ jobs:
             ${{ inputs.eccodes }}
 
   atlas:
-    needs: [eckit]
-    if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.atlas) }}
     name: atlas
-    uses: ecmwf/atlas/.github/workflows/reusable-ci-hpc.yml@develop
-    with:
-      atlas: ${{ inputs.atlas }}
-      eckit: ${{ inputs.eckit }}
-    secrets: inherit
+    needs: [setup, eckit]
+    if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.atlas) }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+    runs-on:
+      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
+    steps:
+      - uses: ecmwf-actions/reusable-workflows/ci-hpc@feature/hpc-action
+        with:
+          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+          repository: ${{ inputs.atlas }}
+          build_config: .github/ci-hpc-config.yml
+          dependencies: |
+            ${{ inputs.eckit }}

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -7,6 +7,10 @@ on:
         description: Whether to use runner with dev version of build-package-hpc .
         required: false
         type: boolean
+      skip_matrix_jobs:
+        description: List of matrix jobs to be skipped.
+        required: false
+        type: string
       eccodes:
         required: false
         type: string
@@ -21,8 +25,49 @@ on:
         type: string
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set Matrix
+        id: set-matrix
+        shell: python
+        run: |
+          import os
+          import json
+          import yaml
+
+          matrix_yaml = """
+            name:
+            - gnu
+            include:
+            - name: gnu
+              os: ubuntu-latest
+              compiler: gnu
+              compiler_cc: gcc
+              compiler_cxx: g++
+              compiler_fc: gfortran
+          """
+
+          matrix = yaml.safe_load(matrix_yaml)
+
+          skip_jobs = """${{ inputs.skip_matrix_jobs }}""".splitlines()
+          if skip_jobs:
+            matrix['name'] = [name for name in matrix['name'] if name not in skip_jobs]
+            matrix['include'] = [d for d in matrix['include'] if d['name'] not in skip_jobs]
+
+          print("Build matrix:")
+          print(yaml.dump(matrix, sort_keys=False))
+
+          with open(os.getenv("GITHUB_OUTPUT"), "a") as f:
+              print(f"matrix<<EOF", file=f)
+              print(json.dumps(matrix, separators=(',', ':')), file=f)
+              print("EOF", file=f)
+
   eccodes:
     name: eccodes
+    needs: [setup]
     if: ${{ inputs.eccodes }}
     runs-on:
       [self-hosted, linux, "${{ inputs.dev-runner && 'hpc-dev' || 'hpc' }}"]

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -82,3 +82,32 @@ jobs:
           troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
           repository: ${{ inputs.eccodes }}
           build_config: .github/ci-hpc-config.yml
+
+  eckit:
+    name: eckit
+    if: ${{ inputs.eckit }}
+    uses: ecmwf/eckit/.github/workflows/reusable-ci-hpc.yml@develop
+    with:
+      eckit: ${{ inputs.eckit }}
+    secrets: inherit
+
+  metkit:
+    needs: [eckit, eccodes]
+    if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.metkit) }}
+    name: metkit
+    uses: ecmwf/metkit/.github/workflows/reusable-ci-hpc.yml@develop
+    with:
+      metkit: ${{ inputs.metkit }}
+      eckit: ${{ inputs.eckit }}
+      eccodes: ${{ inputs.eccodes }}
+    secrets: inherit
+
+  atlas:
+    needs: [eckit]
+    if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.atlas) }}
+    name: atlas
+    uses: ecmwf/atlas/.github/workflows/reusable-ci-hpc.yml@develop
+    with:
+      atlas: ${{ inputs.atlas }}
+      eckit: ${{ inputs.eckit }}
+    secrets: inherit

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -85,11 +85,21 @@ jobs:
 
   eckit:
     name: eckit
+    needs: [setup]
     if: ${{ inputs.eckit }}
-    uses: ecmwf/eckit/.github/workflows/reusable-ci-hpc.yml@develop
-    with:
-      eckit: ${{ inputs.eckit }}
-    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+    runs-on:
+      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
+    steps:
+      - uses: ecmwf-actions/reusable-workflows/ci-hpc@feature/hpc-action
+        with:
+          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+          repository: ${{ inputs.eckit }}
+          build_config: .github/ci-hpc-config.yml
 
   metkit:
     needs: [eckit, eccodes]

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -102,15 +102,25 @@ jobs:
           build_config: .github/ci-hpc-config.yml
 
   metkit:
-    needs: [eckit, eccodes]
-    if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.metkit) }}
     name: metkit
-    uses: ecmwf/metkit/.github/workflows/reusable-ci-hpc.yml@develop
-    with:
-      metkit: ${{ inputs.metkit }}
-      eckit: ${{ inputs.eckit }}
-      eccodes: ${{ inputs.eccodes }}
-    secrets: inherit
+    needs: [setup, eckit, eccodes]
+    if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.metkit) }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+    runs-on:
+      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
+    steps:
+      - uses: ecmwf-actions/reusable-workflows/ci-hpc@feature/hpc-action
+        with:
+          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+          repository: ${{ inputs.metkit }}
+          build_config: .github/ci-hpc-config.yml
+          dependencies: |
+            ${{ inputs.eckit }}
+            ${{ inputs.eccodes }}
 
   atlas:
     needs: [eckit]

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -3,7 +3,7 @@ name: downstream ci hpc
 on:
   workflow_call:
     inputs:
-      dev-runner:
+      dev_runner:
         description: Whether to use runner with dev version of build-package-hpc .
         required: false
         type: boolean
@@ -70,7 +70,7 @@ jobs:
     needs: [setup]
     if: ${{ inputs.eccodes }}
     runs-on:
-      [self-hosted, linux, "${{ inputs.dev-runner && 'hpc-dev' || 'hpc' }}"]
+      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     steps:
       - uses: ecmwf-actions/build-package-hpc@feature/config-file
         with:

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -3,6 +3,10 @@ name: downstream ci hpc
 on:
   workflow_call:
     inputs:
+      dev-runner:
+        description: Whether to use runner with dev version of build-package-hpc .
+        required: false
+        type: boolean
       eccodes:
         required: false
         type: string
@@ -20,36 +24,13 @@ jobs:
   eccodes:
     name: eccodes
     if: ${{ inputs.eccodes }}
-    uses: ecmwf/eccodes/.github/workflows/reusable-ci-hpc.yml@develop
-    with:
-      eccodes: ${{ inputs.eccodes }}
-    secrets: inherit
-
-  eckit:
-    name: eckit
-    if: ${{ inputs.eckit }}
-    uses: ecmwf/eckit/.github/workflows/reusable-ci-hpc.yml@develop
-    with:
-      eckit: ${{ inputs.eckit }}
-    secrets: inherit
-
-  metkit:
-    needs: [eckit, eccodes]
-    if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.metkit) }}
-    name: metkit
-    uses: ecmwf/metkit/.github/workflows/reusable-ci-hpc.yml@develop
-    with:
-      metkit: ${{ inputs.metkit }}
-      eckit: ${{ inputs.eckit }}
-      eccodes: ${{ inputs.eccodes }}
-    secrets: inherit
-
-  atlas:
-    needs: [eckit]
-    if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.atlas) }}
-    name: atlas
-    uses: ecmwf/atlas/.github/workflows/reusable-ci-hpc.yml@develop
-    with:
-      atlas: ${{ inputs.atlas }}
-      eckit: ${{ inputs.eckit }}
-    secrets: inherit
+    runs-on:
+      [self-hosted, linux, "${{ inputs.dev-runner && 'hpc-dev' || 'hpc' }}"]
+    steps:
+      - uses: ecmwf-actions/build-package-hpc@feature/config-file
+        with:
+          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+          troika_user: ${{ secrets.HPC_CI_SSH_USER }}
+          repository: ${{ inputs.eccodes }}
+          build_config: .github/ci-hpc-config.yml

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -69,6 +69,9 @@ jobs:
     name: eccodes
     needs: [setup]
     if: ${{ inputs.eccodes }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     runs-on:
       [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     steps:

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -141,3 +141,26 @@ jobs:
           build_config: .github/ci-hpc-config.yml
           dependencies: |
             ${{ inputs.eckit }}
+
+  mir:
+    name: mir
+    needs: [setup, eckit, eccodes, metkit, atlas]
+    if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.mir) }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+    runs-on:
+      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
+    steps:
+      - uses: ecmwf-actions/reusable-workflows/ci-hpc@feature/hpc-action
+        with:
+          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+          repository: ${{ inputs.mir }}
+          build_config: .github/ci-hpc-config.yml
+          dependencies: |
+            ${{ inputs.eckit }}
+            ${{ inputs.eccodes }}
+            ${{ inputs.metkit }}
+            ${{ inputs.atlas }}

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -79,6 +79,6 @@ jobs:
         with:
           github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
           github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ secrets.HPC_CI_SSH_USER }}
+          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
           repository: ${{ inputs.eccodes }}
           build_config: .github/ci-hpc-config.yml

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -23,7 +23,9 @@ on:
       atlas:
         required: false
         type: string
-
+      mir:
+        required: false
+        type: string
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on:
       [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     steps:
-      - uses: ecmwf-actions/build-package-hpc@feature/config-file
+      - uses: ecmwf-actions/reusable-workflows/ci-hpc@feature/hpc-action
         with:
           github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
           github_token: ${{ secrets.GH_REPO_READ_TOKEN }}

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -170,3 +170,24 @@ jobs:
           build_config: .github/ci-config.yml
           build_dependencies: |
             ${{ inputs.eckit }}
+
+  mir:
+    name: mir
+    needs: [setup, eckit, eccodes, metkit, atlas]
+    if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.mir) }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+    runs-on: ${{ matrix.labels }}
+    steps:
+      - uses: ecmwf-actions/reusable-workflows/build-package-action@feature/build-package-action
+        with:
+          repository: ${{ inputs.mir }}
+          build_package_inputs: |
+            repository: ${{ inputs.mir }}
+          build_config: .github/ci-config.yml
+          build_dependencies: |
+            ${{ inputs.eccodes }}
+            ${{ inputs.eckit }}
+            ${{ inputs.metkit }}
+            ${{ inputs.atlas }}

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -3,6 +3,10 @@ name: downstream ci
 on:
   workflow_call:
     inputs:
+      skip_matrix_jobs:
+        description: List of matrix jobs to be skipped.
+        required: false
+        type: string
       eccodes:
         required: false
         type: string
@@ -17,6 +21,86 @@ on:
         type: string
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set Matrix
+        id: set-matrix
+        shell: python
+        run: |
+          import os
+          import json
+          import yaml
+
+          matrix_yaml = """
+          name:
+          - gnu@debian-11
+          - gnu@centos-7.9
+          - gnu@rocky-8.6
+          - clang@rocky-8.6
+          - gnu@ubuntu-22.04
+          - gnu@fedora-37
+          include:
+          - name: gnu@debian-11
+            labels: [self-hosted, platform-builder-debian-11]
+            os: debian-11
+            compiler: gnu
+            compiler_cc: gcc
+            compiler_cxx: g++
+            compiler_fc: gfortran
+          - name: gnu@centos-7.9
+            labels: [self-hosted, platform-builder-centos-7.9]
+            os: centos-7.9
+            compiler: gnu
+            compiler_cc: gcc
+            compiler_cxx: g++
+            compiler_fc: gfortran
+          - name: gnu@rocky-8.6
+            labels: [self-hosted, platform-builder-rocky-8.6]
+            os: rocky-8.6
+            compiler: gnu
+            compiler_cc: gcc
+            compiler_cxx: g++
+            compiler_fc: gfortran
+          - name: clang@rocky-8.6
+            labels: [self-hosted, platform-builder-rocky-8.6]
+            os: rocky-8.6
+            compiler: clang
+            compiler_cc: clang
+            compiler_cxx: clang++
+            compiler_fc: gfortran
+          - name: gnu@ubuntu-22.04
+            labels: [self-hosted, platform-builder-ubuntu-22.04]
+            os: ubuntu-22.04
+            compiler: gnu
+            compiler_cc: gcc
+            compiler_cxx: g++
+            compiler_fc: gfortran
+          - name: gnu@fedora-37
+            labels: [self-hosted, platform-builder-fedora-37]
+            os: fedora-37
+            compiler: gnu
+            compiler_cc: gcc
+            compiler_cxx: g++
+            compiler_fc: gfortran
+          """
+
+          matrix = yaml.safe_load(matrix_yaml)
+
+          skip_jobs = """${{ inputs.skip_matrix_jobs }}""".splitlines()
+          if skip_jobs:
+            matrix['name'] = [name for name in matrix['name'] if name not in skip_jobs]
+            matrix['include'] = [d for d in matrix['include'] if d['name'] not in skip_jobs]
+
+          print("Build matrix:")
+          print(yaml.dump(matrix, sort_keys=False))
+
+          with open(os.getenv("GITHUB_OUTPUT"), "a") as f:
+              print(f"matrix<<EOF", file=f)
+              print(json.dumps(matrix, separators=(',', ':')), file=f)
+              print("EOF", file=f)
   eccodes:
     name: eccodes
     if: ${{ inputs.eccodes }}

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -114,7 +114,7 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/build-package-action@feature/build-package-action
+      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
         with:
           repository: ${{ inputs.eccodes }}
           build_package_inputs: |
@@ -130,7 +130,7 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/build-package-action@feature/build-package-action
+      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
         with:
           repository: ${{ inputs.eckit }}
           build_package_inputs: |
@@ -146,7 +146,7 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/build-package-action@feature/build-package-action
+      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
         with:
           repository: ${{ inputs.metkit }}
           build_package_inputs: |
@@ -165,7 +165,7 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/build-package-action@feature/build-package-action
+      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
         with:
           repository: ${{ inputs.atlas }}
           build_package_inputs: |
@@ -183,7 +183,7 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/build-package-action@feature/build-package-action
+      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
         with:
           repository: ${{ inputs.mir }}
           build_package_inputs: |

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -101,13 +101,22 @@ jobs:
               print(f"matrix<<EOF", file=f)
               print(json.dumps(matrix, separators=(',', ':')), file=f)
               print("EOF", file=f)
+
   eccodes:
     name: eccodes
+    needs: [setup]
     if: ${{ inputs.eccodes }}
-    uses: ecmwf/eccodes/.github/workflows/reusable-ci.yml@develop
-    with:
-      eccodes: ${{ inputs.eccodes }}
-    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+    runs-on: ${{ matrix.labels }}
+    steps:
+      - uses: ecmwf-actions/reusable-workflows/build-package-action@feature/build-package-action
+        with:
+          repository: ${{ inputs.eccodes }}
+          build_package_inputs: |
+            repository: ${{ inputs.eccodes }}
+          build_config: .github/ci-config.yml
 
   eckit:
     name: eckit

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -19,6 +19,9 @@ on:
       atlas:
         required: false
         type: string
+      mir:
+        required: false
+        type: string
 
 jobs:
   setup:

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -120,11 +120,19 @@ jobs:
 
   eckit:
     name: eckit
+    needs: [setup]
     if: ${{ inputs.eckit }}
-    uses: ecmwf/eckit/.github/workflows/reusable-ci.yml@develop
-    with:
-      eckit: ${{ inputs.eckit }}
-    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+    runs-on: ${{ matrix.labels }}
+    steps:
+      - uses: ecmwf-actions/reusable-workflows/build-package-action@feature/build-package-action
+        with:
+          repository: ${{ inputs.eckit }}
+          build_package_inputs: |
+            repository: ${{ inputs.eckit }}
+          build_config: .github/ci-config.yml
 
   metkit:
     needs: [eckit, eccodes]

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -154,11 +154,19 @@ jobs:
             ${{ inputs.eckit }}
 
   atlas:
-    needs: [eckit]
-    if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.atlas) }}
     name: atlas
-    uses: ecmwf/atlas/.github/workflows/reusable-ci.yml@develop
-    with:
-      atlas: ${{ inputs.atlas }}
-      eckit: ${{ inputs.eckit }}
-    secrets: inherit
+    needs: [setup, eckit]
+    if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.atlas) }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+    runs-on: ${{ matrix.labels }}
+    steps:
+      - uses: ecmwf-actions/reusable-workflows/build-package-action@feature/build-package-action
+        with:
+          repository: ${{ inputs.atlas }}
+          build_package_inputs: |
+            repository: ${{ inputs.atlas }}
+          build_config: .github/ci-config.yml
+          build_dependencies: |
+            ${{ inputs.eckit }}

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -135,15 +135,23 @@ jobs:
           build_config: .github/ci-config.yml
 
   metkit:
-    needs: [eckit, eccodes]
-    if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.metkit) }}
     name: metkit
-    uses: ecmwf/metkit/.github/workflows/reusable-ci.yml@develop
-    with:
-      metkit: ${{ inputs.metkit }}
-      eccodes: ${{ inputs.eccodes }}
-      eckit: ${{ inputs.eckit }}
-    secrets: inherit
+    needs: [setup, eckit, eccodes]
+    if: ${{ always() && (contains(join(needs.*.result, ','), 'success') || inputs.metkit) }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+    runs-on: ${{ matrix.labels }}
+    steps:
+      - uses: ecmwf-actions/reusable-workflows/build-package-action@feature/build-package-action
+        with:
+          repository: ${{ inputs.metkit }}
+          build_package_inputs: |
+            repository: ${{ inputs.metkit }}
+          build_config: .github/ci-config.yml
+          build_dependencies: |
+            ${{ inputs.eccodes }}
+            ${{ inputs.eckit }}
 
   atlas:
     needs: [eckit]


### PR DESCRIPTION
Add build matrix and call composite actions for build-package and build-package-hpc directly instead of reusable workflows.