### PR TITLE
Add HPC compiler matrix

### DIFF
--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -44,8 +44,9 @@ jobs:
             name:
             - gnu-12.2.0
             - gnu-8.5.0
-            - gnu-10.3.0
+            # - gnu-10.3.0
             - nvidia-22.11
+            - intel-2021.4.0
             include:
             - name: gnu-12.2.0
               compiler: gnu-12.2.0
@@ -72,6 +73,12 @@ jobs:
               compiler_cxx: nvc++
               compiler_fc: nvfortran
               compiler_modules: prgenv/nvidia,nvidia/22.11
+            - name: intel-2021.4.0
+              compiler: intel-2021.4.0
+              compiler_cc: icc
+              compiler_cxx: icpc
+              compiler_fc: ifort
+              compiler_modules: prgenv/intel,intel/2021.4.0
           """
 
           matrix = yaml.safe_load(matrix_yaml)

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -45,6 +45,7 @@ jobs:
             - gnu-12.2.0
             - gnu-8.5.0
             - gnu-10.3.0
+            - nvidia-22.11
             include:
             - name: gnu-12.2.0
               compiler: gnu-12.2.0
@@ -58,12 +59,19 @@ jobs:
               compiler_cxx: g++
               compiler_fc: gfortran
               compiler_modules: gcc/8.5.0
-            - name: gnu-10.3.0
-              compiler: gnu-10.3.0
-              compiler_cc: gcc
-              compiler_cxx: g++
-              compiler_fc: gfortran
-              compiler_modules: gcc/10.3.0
+            # some modules are missing for this version
+            # - name: gnu-10.3.0
+            #   compiler: gnu-10.3.0
+            #   compiler_cc: gcc
+            #   compiler_cxx: g++
+            #   compiler_fc: gfortran
+            #   compiler_modules: gcc/10.3.0
+            - name: nvidia-22.11
+              compiler: nvidia-22.11
+              compiler_cc: nvc
+              compiler_cxx: nvc++
+              compiler_fc: nvfortran
+              compiler_modules: prgenv/nvidia,nvidia/22.11
           """
 
           matrix = yaml.safe_load(matrix_yaml)

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -42,14 +42,28 @@ jobs:
 
           matrix_yaml = """
             name:
-            - gnu
+            - gnu-12.2.0
+            - gnu-8.5.0
+            - gnu-10.3.0
             include:
-            - name: gnu
-              os: ubuntu-latest
-              compiler: gnu
+            - name: gnu-12.2.0
+              compiler: gnu-12.2.0
               compiler_cc: gcc
               compiler_cxx: g++
               compiler_fc: gfortran
+              compiler_modules: gcc/12.2.0
+            - name: gnu-8.5.0
+              compiler: gnu-8.5.0
+              compiler_cc: gcc
+              compiler_cxx: g++
+              compiler_fc: gfortran
+              compiler_modules: gcc/8.5.0
+            - name: gnu-10.3.0
+              compiler: gnu-10.3.0
+              compiler_cc: gcc
+              compiler_cxx: g++
+              compiler_fc: gfortran
+              compiler_modules: gcc/10.3.0
           """
 
           matrix = yaml.safe_load(matrix_yaml)

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -43,7 +43,6 @@ jobs:
         id: setup
         env:
           TOKEN: ${{ secrets.GH_REPO_READ_TOKEN }}
-          INPUTS: ${{ toJSON(inputs) }}
           CONFIG_PATHS: |
             ${{ inputs.eccodes || 'ecmwf/eccodes@develop' }}: .github/ci-config.yml
             ${{ inputs.eckit || 'ecmwf/eckit@develop' }}: .github/ci-config.yml

--- a/setup_downstream_ci.py
+++ b/setup_downstream_ci.py
@@ -5,7 +5,6 @@ import requests
 import yaml
 
 # Load inputs
-inputs = os.getenv("INPUTS")
 config_paths: dict = yaml.safe_load(os.getenv("CONFIG_PATHS", ""))
 matrix = yaml.safe_load(os.getenv("MATRIX", ""))
 skip_jobs = os.getenv("SKIP_MATRIX_JOBS", "").splitlines()


### PR DESCRIPTION
Adds build matrix with the following compilers: gnu/12.2.0, gnu/8.5.0, nvidia/22.11 and intel/2021.4.0. gnu/10.3.0 is temporarily disabled, as certain modules are not available for this version (e.g. netcdf4)