### PR TITLE
Add eccodes-python as proper dependency of earthkit-data

### DIFF
--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -630,7 +630,7 @@ jobs:
   earthkit-data:
     name: earthkit-data
     needs: [setup, cfgrib, pdbufr, pyodc]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.earthkit-data && (inputs.cfgrib || inputs.multiurl || inputs.pdbufr || inputs.pyodc || inputs.earthkit-data) }}
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.earthkit-data && (inputs.cfgrib || inputs.eccodes-python || inputs.multiurl || inputs.pdbufr || inputs.pyodc || inputs.earthkit-data) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.earthkit-data) }}
@@ -648,6 +648,7 @@ jobs:
           build_config: ${{ matrix.config_path }}
           python_dependencies: |
             ${{ inputs.cfgrib }}
+            ${{ inputs.eccodes-python }}
             ${{ inputs.multiurl }}
             ${{ inputs.pdbufr }}
             ${{ inputs.pyodc }}

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -728,7 +728,7 @@ jobs:
   earthkit-data:
     name: earthkit-data
     needs: [setup, cfgrib, pdbufr, pyodc]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.earthkit-data && (inputs.cfgrib || inputs.multiurl || inputs.pdbufr || inputs.pyodc || inputs.earthkit-data) }}
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.earthkit-data && (inputs.cfgrib || inputs.eccodes-python|| inputs.multiurl || inputs.pdbufr || inputs.pyodc || inputs.earthkit-data) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.earthkit-data) }}
@@ -753,6 +753,7 @@ jobs:
           lib_path: ${{ steps.build-deps.outputs.lib_path }}
           python_dependencies: |
             ${{ inputs.cfgrib || 'ecmwf/cfgrib@master' }}
+            ${{ inputs.eccodes-python || 'ecmwf/eccodes-python@develop' }}
             ${{ inputs.multiurl || 'ecmwf/multiurl@main' }}
             ${{ inputs.pdbufr || 'ecmwf/pdbufr@master' }}
             ${{ inputs.pyodc || 'ecmwf/pyodc@develop' }}


### PR DESCRIPTION
When running earthkit-data tests, we want to make sure we are getting the latest develop version of eccodes-python from GitHub rather than the version on PyPi.