### PR TITLE
Generate downstream-ci workflows dynamically 

### DIFF
--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -1,21 +1,18 @@
-name: downstream ci hpc
-
-on:
+name: downstream-ci-hpc
+'on':
   workflow_call:
     inputs:
       dev_runner:
         description: Whether to use runner with dev version of build-package-hpc .
         required: false
         type: boolean
-      skip_matrix_jobs:
-        description: List of matrix jobs to be skipped.
-        required: false
-        type: string
-      # packages
       atlas:
         required: false
         type: string
       cfgrib:
+        required: false
+        type: string
+      earthkit-data:
         required: false
         type: string
       eccodes:
@@ -47,7 +44,7 @@ on:
         type: string
       multiurl:
         required: false
-        type: string 
+        type: string
       odc:
         required: false
         type: string
@@ -69,18 +66,18 @@ on:
       thermofeel:
         required: false
         type: string
-      earthkit-data:
+      skip_matrix_jobs:
+        description: List of matrix jobs to be skipped.
         required: false
         type: string
-
-
 jobs:
   setup:
+    name: setup
     runs-on: ubuntu-latest
     outputs:
-      dep_tree: ${{ steps.setup.outputs.build_package_hpc_dep_tree }}
       atlas: ${{ steps.setup.outputs.atlas }}
       cfgrib: ${{ steps.setup.outputs.cfgrib }}
+      earthkit-data: ${{ steps.setup.outputs.earthkit-data }}
       eccodes: ${{ steps.setup.outputs.eccodes }}
       eccodes-python: ${{ steps.setup.outputs.eccodes-python }}
       ecflow: ${{ steps.setup.outputs.ecflow }}
@@ -98,586 +95,675 @@ jobs:
       pyodc: ${{ steps.setup.outputs.pyodc }}
       skinnywms: ${{ steps.setup.outputs.skinnywms }}
       thermofeel: ${{ steps.setup.outputs.thermofeel }}
-      earthkit-data: ${{ steps.setup.outputs.earthkit-data }}
+      dep_tree: ${{ steps.setup.outputs.build_package_hpc_dep_tree }}
     steps:
-      - name: checkout reusable wfs repo
-        uses: actions/checkout@v4
-        with:
-          repository: "ecmwf-actions/downstream-ci"
-          ref: "main"
+    - name: checkout reusable wfs repo
+      uses: actions/checkout@v4
+      with:
+        repository: ecmwf-actions/downstream-ci
+        ref: main
+    - name: Run setup script
+      id: setup
+      env:
+        TOKEN: ${{ secrets.GH_REPO_READ_TOKEN }}
+        CONFIG: |
+          ecmwf/atlas:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.atlas }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/cfgrib:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.cfgrib }}
+            python: true
+            master_branch: master
+            develop_branch: master
+          ecmwf/earthkit-data:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.earthkit-data }}
+            python: true
+            master_branch: main
+            develop_branch: develop
+          ecmwf/eccodes:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.eccodes }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/eccodes-python:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.eccodes-python }}
+            python: true
+            master_branch: master
+            develop_branch: develop
+          ecmwf/ecflow:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.ecflow }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/ecflow-light:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.ecflow-light }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/eckit:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.eckit }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/fckit:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.fckit }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/fdb:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.fdb }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/metkit:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.metkit }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/mir:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.mir }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/multiurl:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.multiurl }}
+            python: true
+            master_branch: main
+            develop_branch: main
+          ecmwf/odc:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.odc }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/pdbufr:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.pdbufr }}
+            python: true
+            master_branch: master
+            develop_branch: master
+          ecmwf/plume:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.plume }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/pyfdb:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.pyfdb }}
+            python: true
+            master_branch: master
+            develop_branch: develop
+          ecmwf/pyodc:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.pyodc }}
+            python: true
+            master_branch: master
+            develop_branch: develop
+          ecmwf/skinnywms:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.skinnywms }}
+            python: true
+            master_branch: master
+            develop_branch: develop
+          ecmwf/thermofeel:
+            path: .github/ci-hpc-config.yml
+            input: ${{ inputs.thermofeel }}
+            python: true
+            master_branch: master
+            develop_branch: develop
+        SKIP_MATRIX_JOBS: ${{ inputs.skip_matrix_jobs }}
+        PYTHON_VERSIONS: |+
+          - '3.10'
 
-      - name: Run setup script
-        id: setup
-        env:
-          TOKEN: ${{ secrets.GH_REPO_READ_TOKEN }}
-          CONFIG: |
-            ecmwf/atlas:
-              path: .github/ci-hpc-config.yml
-              input: ${{ inputs.atlas }}
-            ecmwf/cfgrib:
-              path: .github/ci-hpc-config.yml
-              master_branch: master
-              develop_branch: master
-              python: true
-              input: ${{ inputs.cfgrib }}
-            ecmwf/eccodes:
-              path: .github/ci-hpc-config.yml
-              input: ${{ inputs.eccodes }}
-            ecmwf/eccodes-python:
-              path: .github/ci-hpc-config.yml
-              python: true
-              input: ${{ inputs.eccodes-python }}
-            ecmwf/ecflow:
-              path: .github/ci-hpc-config.yml
-              input: ${{ inputs.ecflow }}
-            ecmwf/ecflow-light:
-              path: .github/ci-hpc-config.yml
-              input: ${{ inputs.ecflow-light }}
-            ecmwf/eckit:
-              path: .github/ci-hpc-config.yml
-              input: ${{ inputs.eckit }}
-            ecmwf/fckit:
-              path: .github/ci-hpc-config.yml
-              input: ${{ inputs.fckit }}
-            ecmwf/fdb:
-              path: .github/ci-hpc-config.yml
-              input: ${{ inputs.fdb }}
-            ecmwf/metkit:
-              path: .github/ci-hpc-config.yml
-              input: ${{ inputs.metkit }}
-            ecmwf/mir:
-              path: .github/ci-hpc-config.yml
-              input: ${{ inputs.mir }}
-            ecmwf/multiurl:
-              path: .github/ci-hpc-config.yml
-              master_branch: main
-              develop_branch: main
-              python: true
-              input: ${{ inputs.multiurl }}
-            ecmwf/odc:
-              path: .github/ci-hpc-config.yml
-              input: ${{ inputs.odc }}
-            ecmwf/pdbufr:
-              path: .github/ci-hpc-config.yml
-              python: true
-              master_branch: master
-              develop_branch: master
-              input: ${{ inputs.pdbufr }}
-            ecmwf/plume:
-              path: .github/ci-hpc-config.yml
-              input: ${{ inputs.plume }}
-            ecmwf/pyfdb:
-              path: .github/ci-hpc-config.yml
-              python: true
-              input: ${{ inputs.pyfdb }}
-            ecmwf/pyodc:
-              path: .github/ci-hpc-config.yml
-              python: true
-              input: ${{ inputs.pyodc }}
-            ecmwf/skinnywms:
-              path: .github/ci-hpc-config.yml
-              python: true
-              input: ${{ inputs.skinnywms }}
-            ecmwf/thermofeel:
-                path: .github/ci-hpc-config.yml
-                python: true
-                input: ${{ inputs.thermofeel }}
-            ecmwf/earthkit-data:
-              path: .github/ci-hpc-config.yml
-              python: true
-              master_branch: main
-              input: ${{ inputs.earthkit-data }}
-          SKIP_MATRIX_JOBS: |
-            gnu-10.3.0
-            ${{ inputs.skip_matrix_jobs }}
-          PYTHON_VERSIONS: |
-            - "3.10"
-          PYTHON_JOBS: |
-            - gnu-8.5.0
-          MATRIX: |
-            name:
-            - gnu-12.2.0
-            - gnu-8.5.0
-            - gnu-10.3.0
-            - nvidia-22.11
-            - intel-2021.4.0
-            include:
-            - name: gnu-12.2.0
-              compiler: gnu-12.2.0
-              compiler_cc: gcc
-              compiler_cxx: g++
-              compiler_fc: gfortran
-              compiler_modules: gcc/12.2.0
-            - name: gnu-8.5.0
-              compiler: gnu-8.5.0
-              compiler_cc: gcc
-              compiler_cxx: g++
-              compiler_fc: gfortran
-              compiler_modules: gcc/8.5.0
-            - name: gnu-10.3.0
-              compiler: gnu-10.3.0
-              compiler_cc: gcc
-              compiler_cxx: g++
-              compiler_fc: gfortran
-              compiler_modules: gcc/10.3.0
-            - name: nvidia-22.11
-              compiler: nvidia-22.11
-              compiler_cc: nvc
-              compiler_cxx: nvc++
-              compiler_fc: nvfortran
-              compiler_modules: prgenv/nvidia,nvidia/22.11
-            - name: intel-2021.4.0
-              compiler: intel-2021.4.0
-              compiler_cc: icc
-              compiler_cxx: icpc
-              compiler_fc: ifort
-              compiler_modules: prgenv/intel,intel/2021.4.0
-        run: python setup_downstream_ci.py
-
+        MATRIX: |
+          include:
+          - compiler: gnu-12.2.0
+            compiler_cc: gcc
+            compiler_cxx: g++
+            compiler_fc: gfortran
+            compiler_modules: gcc/12.2.0
+            name: gnu-12.2.0
+          - compiler: gnu-8.5.0
+            compiler_cc: gcc
+            compiler_cxx: g++
+            compiler_fc: gfortran
+            compiler_modules: gcc/8.5.0
+            name: gnu-8.5.0
+          - compiler: nvidia-22.11
+            compiler_cc: nvc
+            compiler_cxx: nvc++
+            compiler_fc: nvfortran
+            compiler_modules: prgenv/nvidia,nvidia/22.11
+            name: nvidia-22.11
+          - compiler: intel-2021.4.0
+            compiler_cc: icc
+            compiler_cxx: icpc
+            compiler_fc: ifort
+            compiler_modules: prgenv/intel,intel/2021.4.0
+            name: intel-2021.4.0
+          name:
+          - gnu-12.2.0
+          - gnu-8.5.0
+          - nvidia-22.11
+          - intel-2021.4.0
+      run: python setup_downstream_ci.py
   atlas:
     name: atlas
-    needs: [setup, eckit, fckit]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.atlas && (inputs.eckit || inputs.atlas || inputs.fckit) }}
+    needs:
+    - fckit
+    - eckit
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.atlas && (inputs.fckit || inputs.eckit || inputs.atlas) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.atlas) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          dependencies: |
-            ${{ inputs.eckit }}
-            ${{ inputs.fckit }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: |-
+          inputs.fckit
+          inputs.eckit
+          inputs.ecbuild
+        python_dependencies: ''
   cfgrib:
     name: cfgrib
-    needs: [setup, eccodes, eccodes-python]
+    needs:
+    - eccodes-python
+    - eccodes
+    - setup
     if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.cfgrib && (inputs.eccodes-python || inputs.eccodes || inputs.cfgrib) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.cfgrib) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          dependencies: |
-            ${{ inputs.eccodes }}
-          python_dependencies: |
-            ${{ inputs.eccodes-python }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: |-
+          inputs.eccodes
+          inputs.ecbuild
+        python_dependencies: inputs.eccodes-python
+  earthkit-data:
+    name: earthkit-data
+    needs:
+    - cfgrib
+    - multiurl
+    - pdbufr
+    - eccodes-python
+    - eccodes
+    - pyodc
+    - odc
+    - eckit
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.earthkit-data && (inputs.cfgrib || inputs.multiurl || inputs.pdbufr || inputs.eccodes-python || inputs.eccodes || inputs.pyodc || inputs.odc || inputs.eckit || inputs.earthkit-data) }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.earthkit-data) }}
+    env:
+      DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    steps:
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: |-
+          inputs.eccodes
+          inputs.odc
+          inputs.eckit
+          inputs.ecbuild
+        python_dependencies: |-
+          inputs.cfgrib
+          inputs.multiurl
+          inputs.pdbufr
+          inputs.eccodes-python
+          inputs.pyodc
   eccodes:
     name: eccodes
-    needs: [setup]
-    if: ${{ inputs.eccodes && needs.setup.outputs.eccodes }}
+    needs:
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.eccodes && (inputs.eccodes) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.eccodes) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: inputs.ecbuild
+        python_dependencies: ''
   eccodes-python:
     name: eccodes-python
-    needs: [setup, eccodes]
+    needs:
+    - eccodes
+    - setup
     if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.eccodes-python && (inputs.eccodes || inputs.eccodes-python) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.eccodes-python) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          dependencies: |
-            ${{ inputs.eccodes }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: |-
+          inputs.eccodes
+          inputs.ecbuild
+        python_dependencies: ''
   ecflow:
     name: ecflow
-    needs: [setup]
-    if: ${{ inputs.ecflow && needs.setup.outputs.ecflow }}
+    needs:
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.ecflow && (inputs.ecflow) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.ecflow) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: inputs.ecbuild
+        python_dependencies: ''
   ecflow-light:
     name: ecflow-light
-    needs: [setup]
-    if: ${{ inputs.ecflow-light && needs.setup.outputs.ecflow-light }}
+    needs:
+    - eckit
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.ecflow-light && (inputs.eckit || inputs.ecflow-light) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.ecflow-light) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: |-
+          inputs.eckit
+          inputs.ecbuild
+        python_dependencies: ''
   eckit:
     name: eckit
-    needs: [setup]
-    if: ${{ inputs.eckit && needs.setup.outputs.eckit }}
+    needs:
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.eckit && (inputs.eckit) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.eckit) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: inputs.ecbuild
+        python_dependencies: ''
   fckit:
     name: fckit
-    needs: [setup, eckit]
+    needs:
+    - eckit
+    - setup
     if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.fckit && (inputs.eckit || inputs.fckit) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.fckit) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          dependencies: |
-            ${{ inputs.eckit }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: |-
+          inputs.eckit
+          inputs.ecbuild
+        python_dependencies: ''
   fdb:
     name: fdb
-    needs: [setup, eckit, eccodes, metkit]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.fdb && (inputs.eckit || inputs.eccodes || inputs.metkit || inputs.fdb) }}
+    needs:
+    - metkit
+    - eccodes
+    - eckit
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.fdb && (inputs.metkit || inputs.eccodes || inputs.eckit || inputs.fdb) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.fdb) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          dependencies: |
-            ${{ inputs.eckit }}
-            ${{ inputs.eccodes }}
-            ${{ inputs.metkit }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: |-
+          inputs.metkit
+          inputs.eccodes
+          inputs.eckit
+          inputs.ecbuild
+        python_dependencies: ''
   metkit:
     name: metkit
-    needs: [setup, eckit, eccodes]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.metkit && (inputs.eckit || inputs.eccodes || inputs.metkit) }}
+    needs:
+    - eccodes
+    - eckit
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.metkit && (inputs.eccodes || inputs.eckit || inputs.metkit) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.metkit) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          dependencies: |
-            ${{ inputs.eckit }}
-            ${{ inputs.eccodes }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: |-
+          inputs.eccodes
+          inputs.eckit
+          inputs.ecbuild
+        python_dependencies: ''
   mir:
     name: mir
-    needs: [setup, eckit, eccodes, atlas]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.mir && (inputs.eckit || inputs.eccodes || inputs.atlas || inputs.mir) }}
+    needs:
+    - atlas
+    - fckit
+    - eckit
+    - eccodes
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.mir && (inputs.atlas || inputs.fckit || inputs.eckit || inputs.eccodes || inputs.mir) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.mir) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          dependencies: |
-            ${{ inputs.eckit }}
-            ${{ inputs.eccodes }}
-            ${{ inputs.atlas }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: |-
+          inputs.atlas
+          inputs.fckit
+          inputs.eckit
+          inputs.eccodes
+          inputs.ecbuild
+        python_dependencies: ''
   multiurl:
     name: multiurl
-    needs: [setup]
+    needs:
+    - setup
     if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.multiurl && (inputs.multiurl) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.multiurl) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: ''
+        python_dependencies: ''
   odc:
     name: odc
-    needs: [setup, eckit]
+    needs:
+    - eckit
+    - setup
     if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.odc && (inputs.eckit || inputs.odc) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.odc) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          dependencies: |
-            ${{ inputs.eckit }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: |-
+          inputs.eckit
+          inputs.ecbuild
+        python_dependencies: ''
   pdbufr:
     name: pdbufr
-    needs: [setup, eccodes, eccodes-python]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.pdbufr && (inputs.eccodes || inputs.eccodes-python || inputs.pdbufr) }}
+    needs:
+    - eccodes-python
+    - eccodes
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.pdbufr && (inputs.eccodes-python || inputs.eccodes || inputs.pdbufr) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.pdbufr) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          dependencies: |
-            ${{ inputs.eccodes }}
-          python_dependencies: |
-            ${{ inputs.eccodes-python }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: |-
+          inputs.eccodes
+          inputs.ecbuild
+        python_dependencies: inputs.eccodes-python
   plume:
     name: plume
-    needs: [setup, eckit, fckit, atlas]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.plume && (inputs.eckit || inputs.fckit || inputs.atlas || inputs.plume) }}
+    needs:
+    - atlas
+    - fckit
+    - eckit
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.plume && (inputs.atlas || inputs.fckit || inputs.eckit || inputs.plume) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.plume) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          dependencies: |
-            ${{ inputs.eckit }}
-            ${{ inputs.fckit }}
-            ${{ inputs.atlas }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: |-
+          inputs.atlas
+          inputs.fckit
+          inputs.eckit
+          inputs.ecbuild
+        python_dependencies: ''
   pyfdb:
     name: pyfdb
-    needs: [setup, eckit, eccodes, metkit, fdb]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.pyfdb && (inputs.eckit || inputs.eccodes || inputs.metkit || inputs.fdb || inputs.pyfdb) }}
+    needs:
+    - fdb
+    - metkit
+    - eccodes
+    - eckit
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.pyfdb && (inputs.fdb || inputs.metkit || inputs.eccodes || inputs.eckit || inputs.pyfdb) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.pyfdb) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          dependencies: |
-            ${{ inputs.eckit }}
-            ${{ inputs.eccodes }}
-            ${{ inputs.metkit }}
-            ${{ inputs.fdb }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: |-
+          inputs.fdb
+          inputs.metkit
+          inputs.eccodes
+          inputs.eckit
+          inputs.ecbuild
+        python_dependencies: ''
   pyodc:
     name: pyodc
-    needs: [setup, eckit, odc]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.pyodc && (inputs.eckit || inputs.odc || inputs.pyodc) }}
+    needs:
+    - odc
+    - eckit
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.pyodc && (inputs.odc || inputs.eckit || inputs.pyodc) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.pyodc) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          dependencies: |
-            ${{ inputs.eckit }}
-            ${{ inputs.odc}}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: |-
+          inputs.odc
+          inputs.eckit
+          inputs.ecbuild
+        python_dependencies: ''
   skinnywms:
     name: skinnywms
-    needs: [setup]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.skinnywms && inputs.skinnywms }}
+    needs:
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.skinnywms && (inputs.skinnywms) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.skinnywms) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: ''
+        python_dependencies: ''
   thermofeel:
     name: thermofeel
-    needs: [setup]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.thermofeel && inputs.thermofeel }}
+    needs:
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.thermofeel && (inputs.thermofeel) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.thermofeel) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }} 
-
-  earthkit-data:
-    name: earthkit-data
-    needs: [setup, cfgrib, pdbufr, pyodc]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.earthkit-data && (inputs.cfgrib || inputs.eccodes-python || inputs.multiurl || inputs.pdbufr || inputs.pyodc || inputs.earthkit-data) }}
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.setup.outputs.earthkit-data) }}
-    runs-on:
-      [self-hosted, linux, "${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}"]
-    env:
-      DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
-        with:
-          github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
-          github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-          troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
-          repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          python_dependencies: |
-            ${{ inputs.cfgrib }}
-            ${{ inputs.eccodes-python }}
-            ${{ inputs.multiurl }}
-            ${{ inputs.pdbufr }}
-            ${{ inputs.pyodc }}
-
-
+    - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: ''
+        python_dependencies: ''

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -284,9 +284,8 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
-          inputs.fckit
-          inputs.eckit
-          inputs.ecbuild
+          ${{ inputs.fckit }}
+          ${{ inputs.eckit }}
         python_dependencies: ''
   cfgrib:
     name: cfgrib
@@ -312,10 +311,8 @@ jobs:
         troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
-        dependencies: |-
-          inputs.eccodes
-          inputs.ecbuild
-        python_dependencies: inputs.eccodes-python
+        dependencies: ${{ inputs.eccodes }}
+        python_dependencies: ${{ inputs.eccodes-python }}
   earthkit-data:
     name: earthkit-data
     needs:
@@ -347,16 +344,15 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
-          inputs.eccodes
-          inputs.odc
-          inputs.eckit
-          inputs.ecbuild
+          ${{ inputs.eccodes }}
+          ${{ inputs.odc }}
+          ${{ inputs.eckit }}
         python_dependencies: |-
-          inputs.cfgrib
-          inputs.multiurl
-          inputs.pdbufr
-          inputs.eccodes-python
-          inputs.pyodc
+          ${{ inputs.cfgrib }}
+          ${{ inputs.multiurl }}
+          ${{ inputs.pdbufr }}
+          ${{ inputs.eccodes-python }}
+          ${{ inputs.pyodc }}
   eccodes:
     name: eccodes
     needs:
@@ -379,7 +375,7 @@ jobs:
         troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
-        dependencies: inputs.ecbuild
+        dependencies: ''
         python_dependencies: ''
   eccodes-python:
     name: eccodes-python
@@ -404,9 +400,7 @@ jobs:
         troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
-        dependencies: |-
-          inputs.eccodes
-          inputs.ecbuild
+        dependencies: ${{ inputs.eccodes }}
         python_dependencies: ''
   ecflow:
     name: ecflow
@@ -430,7 +424,7 @@ jobs:
         troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
-        dependencies: inputs.ecbuild
+        dependencies: ''
         python_dependencies: ''
   ecflow-light:
     name: ecflow-light
@@ -455,9 +449,7 @@ jobs:
         troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
-        dependencies: |-
-          inputs.eckit
-          inputs.ecbuild
+        dependencies: ${{ inputs.eckit }}
         python_dependencies: ''
   eckit:
     name: eckit
@@ -481,7 +473,7 @@ jobs:
         troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
-        dependencies: inputs.ecbuild
+        dependencies: ''
         python_dependencies: ''
   fckit:
     name: fckit
@@ -506,9 +498,7 @@ jobs:
         troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
-        dependencies: |-
-          inputs.eckit
-          inputs.ecbuild
+        dependencies: ${{ inputs.eckit }}
         python_dependencies: ''
   fdb:
     name: fdb
@@ -536,10 +526,9 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
-          inputs.metkit
-          inputs.eccodes
-          inputs.eckit
-          inputs.ecbuild
+          ${{ inputs.metkit }}
+          ${{ inputs.eccodes }}
+          ${{ inputs.eckit }}
         python_dependencies: ''
   metkit:
     name: metkit
@@ -566,9 +555,8 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
-          inputs.eccodes
-          inputs.eckit
-          inputs.ecbuild
+          ${{ inputs.eccodes }}
+          ${{ inputs.eckit }}
         python_dependencies: ''
   mir:
     name: mir
@@ -597,11 +585,10 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
-          inputs.atlas
-          inputs.fckit
-          inputs.eckit
-          inputs.eccodes
-          inputs.ecbuild
+          ${{ inputs.atlas }}
+          ${{ inputs.fckit }}
+          ${{ inputs.eckit }}
+          ${{ inputs.eccodes }}
         python_dependencies: ''
   multiurl:
     name: multiurl
@@ -650,9 +637,7 @@ jobs:
         troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
-        dependencies: |-
-          inputs.eckit
-          inputs.ecbuild
+        dependencies: ${{ inputs.eckit }}
         python_dependencies: ''
   pdbufr:
     name: pdbufr
@@ -678,10 +663,8 @@ jobs:
         troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
-        dependencies: |-
-          inputs.eccodes
-          inputs.ecbuild
-        python_dependencies: inputs.eccodes-python
+        dependencies: ${{ inputs.eccodes }}
+        python_dependencies: ${{ inputs.eccodes-python }}
   plume:
     name: plume
     needs:
@@ -708,10 +691,9 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
-          inputs.atlas
-          inputs.fckit
-          inputs.eckit
-          inputs.ecbuild
+          ${{ inputs.atlas }}
+          ${{ inputs.fckit }}
+          ${{ inputs.eckit }}
         python_dependencies: ''
   pyfdb:
     name: pyfdb
@@ -740,11 +722,10 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
-          inputs.fdb
-          inputs.metkit
-          inputs.eccodes
-          inputs.eckit
-          inputs.ecbuild
+          ${{ inputs.fdb }}
+          ${{ inputs.metkit }}
+          ${{ inputs.eccodes }}
+          ${{ inputs.eckit }}
         python_dependencies: ''
   pyodc:
     name: pyodc
@@ -771,9 +752,8 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
-          inputs.odc
-          inputs.eckit
-          inputs.ecbuild
+          ${{ inputs.odc }}
+          ${{ inputs.eckit }}
         python_dependencies: ''
   skinnywms:
     name: skinnywms

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -97,7 +97,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ecmwf-actions/downstream-ci
-        ref: generate-workflow
+        ref: main
     - name: Run setup script
       id: setup
       env:
@@ -130,8 +130,7 @@ jobs:
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.eccodes }}
-            optional_matrix:
-            - lumi
+            optional_matrix: null
           ecmwf/eccodes-python:
             path: .github/ci-hpc-config.yml
             python: true
@@ -259,24 +258,28 @@ jobs:
             compiler_fc: gfortran
             compiler_modules: gcc/12.2.0
             name: gnu-12.2.0
+            site: atos
           - compiler: gnu-8.5.0
             compiler_cc: gcc
             compiler_cxx: g++
             compiler_fc: gfortran
             compiler_modules: gcc/8.5.0
             name: gnu-8.5.0
+            site: atos
           - compiler: nvidia-22.11
             compiler_cc: nvc
             compiler_cxx: nvc++
             compiler_fc: nvfortran
             compiler_modules: prgenv/nvidia,nvidia/22.11
             name: nvidia-22.11
+            site: atos
           - compiler: intel-2021.4.0
             compiler_cc: icc
             compiler_cxx: icpc
             compiler_fc: ifort
             compiler_modules: prgenv/intel,intel/2021.4.0
             name: intel-2021.4.0
+            site: atos
           name:
           - gnu-12.2.0
           - gnu-8.5.0
@@ -289,7 +292,8 @@ jobs:
             compiler_cxx: g++
             compiler_fc: gfortran
             compiler_modules: LUMI/23.09,cpeGNU/23.09
-            name: lumi
+            name: lumi-gnu-12.2.0
+            site: lumi
           name:
           - lumi
       run: python setup_downstream_ci.py

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -2,10 +2,6 @@ name: downstream-ci-hpc
 'on':
   workflow_call:
     inputs:
-      dev_runner:
-        description: Whether to use runner with dev version of build-package-hpc .
-        required: false
-        type: boolean
       atlas:
         required: false
         type: string
@@ -275,13 +271,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.atlas) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
@@ -301,13 +300,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.cfgrib) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
@@ -332,13 +334,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.earthkit-data) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
@@ -362,13 +367,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.eccodes) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: inputs.ecbuild
@@ -384,13 +392,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.eccodes-python) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
@@ -407,13 +418,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.ecflow) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: inputs.ecbuild
@@ -429,13 +443,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.ecflow-light) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
@@ -452,13 +469,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.eckit) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: inputs.ecbuild
@@ -474,13 +494,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.fckit) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
@@ -500,13 +523,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.fdb) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
@@ -527,13 +553,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.metkit) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
@@ -555,13 +584,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.mir) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
@@ -581,13 +613,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.multiurl) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: ''
@@ -603,13 +638,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.odc) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
@@ -628,13 +666,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.pdbufr) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
@@ -654,13 +695,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.plume) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
@@ -683,13 +727,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.pyfdb) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
@@ -711,13 +758,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.pyodc) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: |-
@@ -735,13 +785,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.skinnywms) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: ''
@@ -756,13 +809,16 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.thermofeel) }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    runs-on: '[self-hosted, linux, "${{ inputs.dev_runner && ''hpc-dev'' || ''hpc'' }}"]'
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
     steps:
     - uses: ecmwf-actions/reusable-workflows/ci-hpc@v2
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
         dependencies: ''

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -105,127 +105,130 @@ jobs:
         CONFIG: |
           ecmwf/atlas:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.atlas }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.atlas }}
           ecmwf/cfgrib:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.cfgrib }}
             python: true
             master_branch: master
             develop_branch: master
+            input: ${{ inputs.cfgrib }}
           ecmwf/earthkit-data:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.earthkit-data }}
             python: true
             master_branch: main
             develop_branch: develop
+            input: ${{ inputs.earthkit-data }}
           ecmwf/eccodes:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.eccodes }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.eccodes }}
           ecmwf/eccodes-python:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.eccodes-python }}
             python: true
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.eccodes-python }}
           ecmwf/ecflow:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.ecflow }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.ecflow }}
           ecmwf/ecflow-light:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.ecflow-light }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.ecflow-light }}
           ecmwf/eckit:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.eckit }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.eckit }}
           ecmwf/fckit:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.fckit }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.fckit }}
           ecmwf/fdb:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.fdb }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.fdb }}
           ecmwf/metkit:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.metkit }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.metkit }}
           ecmwf/mir:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.mir }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.mir }}
           ecmwf/multiurl:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.multiurl }}
             python: true
             master_branch: main
             develop_branch: main
+            input: ${{ inputs.multiurl }}
           ecmwf/odc:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.odc }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.odc }}
           ecmwf/pdbufr:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.pdbufr }}
             python: true
             master_branch: master
             develop_branch: master
+            input: ${{ inputs.pdbufr }}
           ecmwf/plume:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.plume }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.plume }}
           ecmwf/pyfdb:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.pyfdb }}
             python: true
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.pyfdb }}
           ecmwf/pyodc:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.pyodc }}
             python: true
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.pyodc }}
           ecmwf/skinnywms:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.skinnywms }}
             python: true
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.skinnywms }}
           ecmwf/thermofeel:
             path: .github/ci-hpc-config.yml
-            input: ${{ inputs.thermofeel }}
             python: true
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.thermofeel }}
         SKIP_MATRIX_JOBS: ${{ inputs.skip_matrix_jobs }}
         PYTHON_VERSIONS: |+
           - '3.10'
+
+        PYTHON_JOBS: |+
+          - gnu-8.5.0
 
         MATRIX: |
           include:

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -97,7 +97,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ecmwf-actions/downstream-ci
-        ref: main
+        ref: generate-workflow
     - name: Run setup script
       id: setup
       env:
@@ -109,120 +109,141 @@ jobs:
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.atlas }}
+            optional_matrix: null
           ecmwf/cfgrib:
             path: .github/ci-hpc-config.yml
             python: true
             master_branch: master
             develop_branch: master
             input: ${{ inputs.cfgrib }}
+            optional_matrix: null
           ecmwf/earthkit-data:
             path: .github/ci-hpc-config.yml
             python: true
             master_branch: main
             develop_branch: develop
             input: ${{ inputs.earthkit-data }}
+            optional_matrix: null
           ecmwf/eccodes:
             path: .github/ci-hpc-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.eccodes }}
+            optional_matrix:
+            - lumi
           ecmwf/eccodes-python:
             path: .github/ci-hpc-config.yml
             python: true
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.eccodes-python }}
+            optional_matrix: null
           ecmwf/ecflow:
             path: .github/ci-hpc-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.ecflow }}
+            optional_matrix: null
           ecmwf/ecflow-light:
             path: .github/ci-hpc-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.ecflow-light }}
+            optional_matrix: null
           ecmwf/eckit:
             path: .github/ci-hpc-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.eckit }}
+            optional_matrix: null
           ecmwf/fckit:
             path: .github/ci-hpc-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.fckit }}
+            optional_matrix: null
           ecmwf/fdb:
             path: .github/ci-hpc-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.fdb }}
+            optional_matrix: null
           ecmwf/metkit:
             path: .github/ci-hpc-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.metkit }}
+            optional_matrix: null
           ecmwf/mir:
             path: .github/ci-hpc-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.mir }}
+            optional_matrix: null
           ecmwf/multiurl:
             path: .github/ci-hpc-config.yml
             python: true
             master_branch: main
             develop_branch: main
             input: ${{ inputs.multiurl }}
+            optional_matrix: null
           ecmwf/odc:
             path: .github/ci-hpc-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.odc }}
+            optional_matrix: null
           ecmwf/pdbufr:
             path: .github/ci-hpc-config.yml
             python: true
             master_branch: master
             develop_branch: master
             input: ${{ inputs.pdbufr }}
+            optional_matrix: null
           ecmwf/plume:
             path: .github/ci-hpc-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.plume }}
+            optional_matrix: null
           ecmwf/pyfdb:
             path: .github/ci-hpc-config.yml
             python: true
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.pyfdb }}
+            optional_matrix: null
           ecmwf/pyodc:
             path: .github/ci-hpc-config.yml
             python: true
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.pyodc }}
+            optional_matrix: null
           ecmwf/skinnywms:
             path: .github/ci-hpc-config.yml
             python: true
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.skinnywms }}
+            optional_matrix: null
           ecmwf/thermofeel:
             path: .github/ci-hpc-config.yml
             python: true
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.thermofeel }}
+            optional_matrix: null
         SKIP_MATRIX_JOBS: ${{ inputs.skip_matrix_jobs }}
         PYTHON_VERSIONS: |+
           - '3.10'
@@ -261,6 +282,16 @@ jobs:
           - gnu-8.5.0
           - nvidia-22.11
           - intel-2021.4.0
+        OPTIONAL_MATRIX: |
+          include:
+          - compiler: gnu-12.2.0
+            compiler_cc: gcc
+            compiler_cxx: g++
+            compiler_fc: gfortran
+            compiler_modules: LUMI/23.09,cpeGNU/23.09
+            name: lumi
+          name:
+          - lumi
       run: python setup_downstream_ci.py
   atlas:
     name: atlas

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -1,25 +1,18 @@
-name: downstream ci
-
-on:
+name: downstream-ci
+'on':
   workflow_call:
     inputs:
-      skip_matrix_jobs:
-        description: List of matrix jobs to be skipped.
-        required: false
-        type: string
       codecov_upload:
         description: Whether to upload code coverage
         type: boolean
         required: false
-      python_qa:
-        description: Whether to run code QA tasks.
-        type: boolean
-        required: false
-      # packages
       atlas:
         required: false
         type: string
       cfgrib:
+        required: false
+        type: string
+      earthkit-data:
         required: false
         type: string
       eccodes:
@@ -51,7 +44,7 @@ on:
         type: string
       multiurl:
         required: false
-        type: string 
+        type: string
       odc:
         required: false
         type: string
@@ -73,19 +66,22 @@ on:
       thermofeel:
         required: false
         type: string
-      earthkit-data:
+      skip_matrix_jobs:
+        description: List of matrix jobs to be skipped.
         required: false
         type: string
-
+      python_qa:
+        description: Whether to run code QA tasks.
+        type: boolean
+        required: false
 jobs:
   setup:
+    name: setup
     runs-on: ubuntu-latest
     outputs:
-      dep_tree: ${{ steps.setup.outputs.build_package_dep_tree }}
-      trigger_repo: ${{ steps.setup.outputs.trigger_repo}}
-      py_codecov_platform: ${{ steps.setup.outputs.py_codecov_platform }}
       atlas: ${{ steps.setup.outputs.atlas }}
       cfgrib: ${{ steps.setup.outputs.cfgrib }}
+      earthkit-data: ${{ steps.setup.outputs.earthkit-data }}
       eccodes: ${{ steps.setup.outputs.eccodes }}
       eccodes-python: ${{ steps.setup.outputs.eccodes-python }}
       ecflow: ${{ steps.setup.outputs.ecflow }}
@@ -103,691 +99,787 @@ jobs:
       pyodc: ${{ steps.setup.outputs.pyodc }}
       skinnywms: ${{ steps.setup.outputs.skinnywms }}
       thermofeel: ${{ steps.setup.outputs.thermofeel }}
-      earthkit-data: ${{ steps.setup.outputs.earthkit-data }}
+      dep_tree: ${{ steps.setup.outputs.build_package_dep_tree }}
+      trigger_repo: ${{ steps.setup.outputs.trigger_repo }}
+      py_codecov_platform: ${{ steps.setup.outputs.py_codecov_platform }}
     steps:
-      - name: checkout reusable wfs repo
-        uses: actions/checkout@v4
-        with:
-          repository: "ecmwf-actions/downstream-ci"
-          ref: "main"
+    - name: checkout reusable wfs repo
+      uses: actions/checkout@v4
+      with:
+        repository: ecmwf-actions/downstream-ci
+        ref: main
+    - name: Run setup script
+      id: setup
+      env:
+        TOKEN: ${{ secrets.GH_REPO_READ_TOKEN }}
+        CONFIG: |
+          ecmwf/atlas:
+            path: .github/ci-config.yml
+            input: ${{ inputs.atlas }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/cfgrib:
+            path: .github/ci-config.yml
+            input: ${{ inputs.cfgrib }}
+            python: true
+            master_branch: master
+            develop_branch: master
+          ecmwf/earthkit-data:
+            path: .github/ci-config.yml
+            input: ${{ inputs.earthkit-data }}
+            python: true
+            master_branch: main
+            develop_branch: develop
+          ecmwf/eccodes:
+            path: .github/ci-config.yml
+            input: ${{ inputs.eccodes }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/eccodes-python:
+            path: .github/ci-config.yml
+            input: ${{ inputs.eccodes-python }}
+            python: true
+            master_branch: master
+            develop_branch: develop
+          ecmwf/ecflow:
+            path: .github/ci-config.yml
+            input: ${{ inputs.ecflow }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/ecflow-light:
+            path: .github/ci-config.yml
+            input: ${{ inputs.ecflow-light }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/eckit:
+            path: .github/ci-config.yml
+            input: ${{ inputs.eckit }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/fckit:
+            path: .github/ci-config.yml
+            input: ${{ inputs.fckit }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/fdb:
+            path: .github/ci-config.yml
+            input: ${{ inputs.fdb }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/metkit:
+            path: .github/ci-config.yml
+            input: ${{ inputs.metkit }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/mir:
+            path: .github/ci-config.yml
+            input: ${{ inputs.mir }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/multiurl:
+            path: .github/ci-config.yml
+            input: ${{ inputs.multiurl }}
+            python: true
+            master_branch: main
+            develop_branch: main
+          ecmwf/odc:
+            path: .github/ci-config.yml
+            input: ${{ inputs.odc }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/pdbufr:
+            path: .github/ci-config.yml
+            input: ${{ inputs.pdbufr }}
+            python: true
+            master_branch: master
+            develop_branch: master
+          ecmwf/plume:
+            path: .github/ci-config.yml
+            input: ${{ inputs.plume }}
+            python: false
+            master_branch: master
+            develop_branch: develop
+          ecmwf/pyfdb:
+            path: .github/ci-config.yml
+            input: ${{ inputs.pyfdb }}
+            python: true
+            master_branch: master
+            develop_branch: develop
+          ecmwf/pyodc:
+            path: .github/ci-config.yml
+            input: ${{ inputs.pyodc }}
+            python: true
+            master_branch: master
+            develop_branch: develop
+          ecmwf/skinnywms:
+            path: .github/ci-config.yml
+            input: ${{ inputs.skinnywms }}
+            python: true
+            master_branch: master
+            develop_branch: develop
+          ecmwf/thermofeel:
+            path: .github/ci-config.yml
+            input: ${{ inputs.thermofeel }}
+            python: true
+            master_branch: master
+            develop_branch: develop
+        SKIP_MATRIX_JOBS: ${{ inputs.skip_matrix_jobs }}
+        PYTHON_VERSIONS: |+
+          - '3.10'
 
-      - name: Run setup script
-        id: setup
-        env:
-          # See setup_downstream_ci.py docstring for syntax
-          TOKEN: ${{ secrets.GH_REPO_READ_TOKEN }}
-          CONFIG: |
-            ecmwf/atlas:
-              path: .github/ci-config.yml
-              input: ${{ inputs.atlas }}
-            ecmwf/cfgrib:
-              path: .github/ci-config.yml
-              master_branch: master
-              develop_branch: master
-              python: true
-              input: ${{ inputs.cfgrib }}
-            ecmwf/eccodes:
-              path: .github/ci-config.yml
-              input: ${{ inputs.eccodes }}
-            ecmwf/eccodes-python:
-              path: .github/ci-config.yml
-              python: true
-              input: ${{ inputs.eccodes-python }}
-            ecmwf/ecflow:
-              path: .github/ci-config.yml
-              input: ${{ inputs.ecflow }}
-            ecmwf/ecflow-light:
-              path: .github/ci-config.yml
-              input: ${{ inputs.ecflow-light }}
-            ecmwf/eckit:
-              path: .github/ci-config.yml
-              input: ${{ inputs.eckit }}
-            ecmwf/fckit:
-              path: .github/ci-config.yml
-              input: ${{ inputs.fckit }}
-            ecmwf/fdb:
-              path: .github/ci-config.yml
-              input: ${{ inputs.fdb }}
-            ecmwf/metkit:
-              path: .github/ci-config.yml
-              input: ${{ inputs.metkit }}
-            ecmwf/mir:
-              path: .github/ci-config.yml
-              input: ${{ inputs.mir }}
-            ecmwf/multiurl:
-              master_branch: main
-              develop_branch: main
-              python: true
-              input: ${{ inputs.multiurl }}
-            ecmwf/odc:
-              path: .github/ci-config.yml
-              input: ${{ inputs.odc }}
-            ecmwf/pdbufr:
-              path: .github/ci-config.yml
-              python: true
-              master_branch: master
-              develop_branch: master
-              input: ${{ inputs.pdbufr }}
-            ecmwf/plume:
-              path: .github/ci-config.yml
-              input: ${{ inputs.plume }}
-            ecmwf/pyfdb:
-              path: .github/ci-config.yml
-              python: true
-              input: ${{ inputs.pyfdb }}
-            ecmwf/pyodc:
-              path: .github/ci-config.yml
-              python: true
-              input: ${{ inputs.pyodc }}
-            ecmwf/skinnywms:
-              path: .github/ci-config.yml
-              python: true
-              input: ${{ inputs.skinnywms }}
-            ecmwf/thermofeel:
-              python: true
-              input: ${{ inputs.thermofeel }}
-            ecmwf/earthkit-data:
-              path: .github/ci-config.yml
-              python: true
-              master_branch: main
-              input: ${{ inputs.earthkit-data }}
-          SKIP_MATRIX_JOBS: |
-            ${{ inputs.skip_matrix_jobs }}
-          PYTHON_VERSIONS: |
-            - "3.10"
-          MATRIX: |
-            name:
-            - gnu@debian-11
-            - gnu-7@centos-7.9
-            - gnu-8@centos-7.9
-            - gnu@rocky-8.6
-            - clang@rocky-8.6
-            - gnu@ubuntu-22.04
-            - gnu@fedora-37
-            # - clang@macos-13-arm
-            # - clang@macos-13-x86
-            include:
-            - name: gnu@debian-11
-              labels: [self-hosted, platform-builder-debian-11]
-              os: debian-11
-              compiler: gnu
-              compiler_cc: gcc
-              compiler_cxx: g++
-              compiler_fc: gfortran
-              env: &linux_env |
-                BOOST_ROOT_DIR=/usr
-                BOOST_INCLUDE_DIR=/usr/include/boost169
-                BOOST_LIB_DIR=/usr/lib64/boost169
-            - name: gnu-7@centos-7.9
-              labels: [self-hosted, platform-builder-centos-7.9]
-              os: centos-7.9
-              compiler: gnu-7
-              compiler_cc: gcc-7
-              compiler_cxx: g++-7
-              compiler_fc: gfortran-7
-              env: *linux_env
-            - name: gnu-8@centos-7.9
-              labels: [self-hosted, platform-builder-centos-7.9]
-              os: centos-7.9
-              compiler: gnu-8
-              compiler_cc: gcc-8
-              compiler_cxx: g++-8
-              compiler_fc: gfortran-8
-              env: *linux_env
-            - name: gnu@rocky-8.6
-              labels: [self-hosted, platform-builder-rocky-8.6]
-              os: rocky-8.6
-              compiler: gnu
-              compiler_cc: gcc
-              compiler_cxx: g++
-              compiler_fc: gfortran
-              env: *linux_env
-            - name: clang@rocky-8.6
-              labels: [self-hosted, platform-builder-rocky-8.6]
-              os: rocky-8.6
-              compiler: clang
-              compiler_cc: clang
-              compiler_cxx: clang++
-              compiler_fc: gfortran
-              env: *linux_env
-              toolchain_file: /opt/actions-runner/files/toolchain-clang-rocky-8.6.cmake
-            - name: gnu@ubuntu-22.04
-              labels: [self-hosted, platform-builder-ubuntu-22.04]
-              os: ubuntu-22.04
-              compiler: gnu
-              compiler_cc: gcc
-              compiler_cxx: g++
-              compiler_fc: gfortran
-              env: *linux_env
-            - name: gnu@fedora-37
-              labels: [self-hosted, platform-builder-fedora-37]
-              os: fedora-37
-              compiler: gnu
-              compiler_cc: gcc
-              compiler_cxx: g++
-              compiler_fc: gfortran
-              env: *linux_env
-            # - name: clang@macos-13-arm
-            #   labels: [self-hosted, platform-builder-macosx-13.4.1-arm64]
-            #   os: macos-13-arm
-            #   compiler: clang
-            #   compiler_cc: clang
-            #   compiler_cxx: clang++
-            #   compiler_fc: gfortran
-            #   #OPENSSL_ROOT_DIR is taken care of in build-package
-            #   env: &macos_env |
-            #     BOOST_ROOT_DIR=$(brew --prefix)
-            #     BOOST_INCLUDE_DIR=$(brew --prefix)/include
-            #     BOOST_LIB_DIR=$(brew --prefix)/lib
-            # - name: clang@macos-13-x86
-            #   labels: [self-hosted, platform-builder-macosx-13.4.1-x86_64]
-            #   os: macos-13-x86
-            #   compiler: clang
-            #   compiler_cc: clang
-            #   compiler_cxx: clang++
-            #   compiler_fc: gfortran
-            #   #OPENSSL_ROOT_DIR is taken care of in build-package
-            #   env: *macos_env
-        run: python setup_downstream_ci.py
-
+        MATRIX: |
+          include:
+          - compiler: gnu
+            compiler_cc: gcc
+            compiler_cxx: g++
+            compiler_fc: gfortran
+            env: |
+              BOOST_ROOT_DIR=/usr
+              BOOST_INCLUDE_DIR=/usr/include/boost169
+              BOOST_LIB_DIR=/usr/lib64/boost169
+            labels:
+            - self-hosted
+            - platform-builder-debian-11
+            name: gnu@debian-11
+            os: debian-11
+          - compiler: gnu-7
+            compiler_cc: gcc-7
+            compiler_cxx: g++-7
+            compiler_fc: gfortran-7
+            env: |
+              BOOST_ROOT_DIR=/usr
+              BOOST_INCLUDE_DIR=/usr/include/boost169
+              BOOST_LIB_DIR=/usr/lib64/boost169
+            labels:
+            - self-hosted
+            - platform-builder-centos-7.9
+            name: gnu-7@centos-7.9
+            os: centos-7.9
+          - compiler: gnu-8
+            compiler_cc: gcc-8
+            compiler_cxx: g++-8
+            compiler_fc: gfortran-8
+            env: |
+              BOOST_ROOT_DIR=/usr
+              BOOST_INCLUDE_DIR=/usr/include/boost169
+              BOOST_LIB_DIR=/usr/lib64/boost169
+            labels:
+            - self-hosted
+            - platform-builder-centos-7.9
+            name: gnu-8@centos-7.9
+            os: centos-7.9
+          - compiler: gnu
+            compiler_cc: gcc
+            compiler_cxx: g++
+            compiler_fc: gfortran
+            env: |
+              BOOST_ROOT_DIR=/usr
+              BOOST_INCLUDE_DIR=/usr/include/boost169
+              BOOST_LIB_DIR=/usr/lib64/boost169
+            labels:
+            - self-hosted
+            - platform-builder-rocky-8.6
+            name: gnu@rocky-8.6
+            os: rocky-8.6
+          - compiler: clang
+            compiler_cc: clang
+            compiler_cxx: clang++
+            compiler_fc: gfortran
+            env: |
+              BOOST_ROOT_DIR=/usr
+              BOOST_INCLUDE_DIR=/usr/include/boost169
+              BOOST_LIB_DIR=/usr/lib64/boost169
+            labels:
+            - self-hosted
+            - platform-builder-rocky-8.6
+            name: clang@rocky-8.6
+            os: rocky-8.6
+            toolchain_file: /opt/actions-runner/files/toolchain-clang-rocky-8.6.cmake
+          - compiler: gnu
+            compiler_cc: gcc
+            compiler_cxx: g++
+            compiler_fc: gfortran
+            env: |
+              BOOST_ROOT_DIR=/usr
+              BOOST_INCLUDE_DIR=/usr/include/boost169
+              BOOST_LIB_DIR=/usr/lib64/boost169
+            labels:
+            - self-hosted
+            - platform-builder-ubuntu-22.04
+            name: gnu@ubuntu-22.04
+            os: ubuntu-22.04
+          - compiler: gnu
+            compiler_cc: gcc
+            compiler_cxx: g++
+            compiler_fc: gfortran
+            env: |
+              BOOST_ROOT_DIR=/usr
+              BOOST_INCLUDE_DIR=/usr/include/boost169
+              BOOST_LIB_DIR=/usr/lib64/boost169
+            labels:
+            - self-hosted
+            - platform-builder-fedora-37
+            name: gnu@fedora-37
+            os: fedora-37
+          - compiler: clang
+            compiler_cc: clang
+            compiler_cxx: clang++
+            compiler_fc: gfortran
+            env: |
+              BOOST_ROOT_DIR=$(brew --prefix)
+              BOOST_INCLUDE_DIR=$(brew --prefix)/include
+              BOOST_LIB_DIR=$(brew --prefix)/lib
+            labels:
+            - self-hosted
+            - platform-builder-macosx-13.4.1-arm64
+            name: clang@macos-13-arm
+            os: macos-13-arm
+          - compiler: clang
+            compiler_cc: clang
+            compiler_cxx: clang++
+            compiler_fc: gfortran
+            env: |
+              BOOST_ROOT_DIR=$(brew --prefix)
+              BOOST_INCLUDE_DIR=$(brew --prefix)/include
+              BOOST_LIB_DIR=$(brew --prefix)/lib
+            labels:
+            - self-hosted
+            - platform-builder-macosx-13.4.1-x86_64
+            name: clang@macos-13-x86
+            os: macos-13-x86
+          name:
+          - gnu@debian-11
+          - gnu-7@centos-7.9
+          - gnu-8@centos-7.9
+          - gnu@rocky-8.6
+          - clang@rocky-8.6
+          - gnu@ubuntu-22.04
+          - gnu@fedora-37
+          - clang@macos-13-arm
+          - clang@macos-13-x86
+      run: python setup_downstream_ci.py
   python-qa:
     name: python-qa
-    needs: [setup]
+    needs:
+    - setup
     if: ${{ inputs.python_qa }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ inputs.repository }}
-          ref: ${{ inputs.ref }}
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
-
-      - name: Install Python Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install black flake8 isort
-
-      - name: Check isort
-        run: isort --check .
-
-      - name: Check black
-        run: black --check .
-
-      - name: Check flake8
-        run: flake8 .
-
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.repository }}
+        ref: ${{ inputs.ref }}
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.x
+    - name: Install Python Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install black flake8 isort
+    - name: Check isort
+      run: isort --check .
+    - name: Check black
+      run: black --check .
+    - name: Check flake8
+      run: flake8 .
   atlas:
     name: atlas
-    needs: [setup, eckit, fckit]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.atlas && (inputs.eckit || inputs.atlas || inputs.fckit) }}
+    needs:
+    - fckit
+    - eckit
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.atlas && (inputs.fckit || inputs.eckit || inputs.atlas) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.atlas) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        env:
-          ATLAS_RUN_MPI_ARGS: "--oversubscribe" # for macos runners that do not have enough slots for ctest
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          build_dependencies: |
-            ${{ inputs.eckit }}
-            ${{ inputs.fckit }}
-
+    - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: |-
+          ${{ inputs.fckit }}
+          ${{ inputs.eckit }}
   cfgrib:
     name: cfgrib
-    needs: [setup, eccodes, eccodes-python]
+    needs:
+    - eccodes-python
+    - eccodes
+    - setup
+    - python-qa
     if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.cfgrib && (inputs.eccodes-python || inputs.eccodes || inputs.cfgrib) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.cfgrib) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - name: Build dependencies
-        id: build-deps
-        uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          build_dependencies: |
-            ${{ inputs.eccodes }}
-
-      - uses: ecmwf-actions/reusable-workflows/ci-python@v2
-        with:
-          lib_path: ${{ steps.build-deps.outputs.lib_path }}
-          python_dependencies: ${{ inputs.eccodes-python || 'ecmwf/eccodes-python@develop' }}
-
+    - name: Build dependencies
+      id: build-deps
+      uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: ${{ inputs.eccodes }}
+    - uses: ecmwf-actions/reusable-workflows/ci-python@v2
+      with:
+        lib_path: ${{ steps.build-deps.outputs.lib_path }}
+        conda_install: libffi=3.3
+        python_dependencies: ${{ inputs.eccodes-python }}
+  earthkit-data:
+    name: earthkit-data
+    needs:
+    - cfgrib
+    - multiurl
+    - pdbufr
+    - eccodes-python
+    - eccodes
+    - pyodc
+    - odc
+    - eckit
+    - setup
+    - python-qa
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.earthkit-data && (inputs.cfgrib || inputs.multiurl || inputs.pdbufr || inputs.eccodes-python || inputs.eccodes || inputs.pyodc || inputs.odc || inputs.eckit || inputs.earthkit-data) }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.earthkit-data) }}
+    env:
+      DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
+    steps:
+    - name: Build dependencies
+      id: build-deps
+      uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: |-
+          ${{ inputs.eccodes }}
+          ${{ inputs.odc }}
+          ${{ inputs.eckit }}
+    - uses: ecmwf-actions/reusable-workflows/ci-python@v2
+      with:
+        lib_path: ${{ steps.build-deps.outputs.lib_path }}
+        conda_install: libffi=3.3
+        python_dependencies: |-
+          ${{ inputs.cfgrib }}
+          ${{ inputs.multiurl }}
+          ${{ inputs.pdbufr }}
+          ${{ inputs.eccodes-python }}
+          ${{ inputs.pyodc }}
   eccodes:
     name: eccodes
-    needs: [setup]
-    if: ${{ inputs.eccodes && needs.setup.outputs.eccodes }}
+    needs:
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.eccodes && (inputs.eccodes) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.eccodes) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-
+    - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: ''
   eccodes-python:
     name: eccodes-python
-    needs: [setup, eccodes]
+    needs:
+    - eccodes
+    - setup
+    - python-qa
     if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.eccodes-python && (inputs.eccodes || inputs.eccodes-python) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.eccodes-python) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - name: Build dependencies
-        id: build-deps
-        uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          build_dependencies: |
-            ${{ inputs.eccodes }}
-
-      - uses: ecmwf-actions/reusable-workflows/ci-python@v2
-        with:
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
-          lib_path: ${{ steps.build-deps.outputs.lib_path }}
-
+    - name: Build dependencies
+      id: build-deps
+      uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: ${{ inputs.eccodes }}
+    - uses: ecmwf-actions/reusable-workflows/ci-python@v2
+      with:
+        lib_path: ${{ steps.build-deps.outputs.lib_path }}
+        conda_install: libffi=3.3
+        python_dependencies: ''
   ecflow:
     name: ecflow
-    needs: [setup]
-    if: ${{ inputs.ecflow && needs.setup.outputs.ecflow }}
+    needs:
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.ecflow && (inputs.ecflow) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.ecflow) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-
+    - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: ''
   ecflow-light:
     name: ecflow-light
-    needs: [setup]
-    if: ${{ inputs.ecflow-light && needs.setup.outputs.ecflow-light }}
+    needs:
+    - eckit
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.ecflow-light && (inputs.eckit || inputs.ecflow-light) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.ecflow-light) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-
+    - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: ${{ inputs.eckit }}
   eckit:
     name: eckit
-    needs: [setup]
-    if: ${{ inputs.eckit && needs.setup.outputs.eckit }}
+    needs:
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.eckit && (inputs.eckit) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.eckit) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-
+    - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: ''
   fckit:
     name: fckit
-    needs: [setup, eckit]
+    needs:
+    - eckit
+    - setup
     if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.fckit && (inputs.eckit || inputs.fckit) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.fckit) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          build_dependencies: |
-            ${{ inputs.eckit }}
-
+    - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: ${{ inputs.eckit }}
   fdb:
     name: fdb
-    needs: [setup, eckit, eccodes, metkit]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.fdb && (inputs.eckit || inputs.eccodes || inputs.metkit || inputs.fdb) }}
+    needs:
+    - metkit
+    - eccodes
+    - eckit
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.fdb && (inputs.metkit || inputs.eccodes || inputs.eckit || inputs.fdb) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.fdb) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          build_dependencies: |
-            ${{ inputs.eccodes }}
-            ${{ inputs.eckit }}
-            ${{ inputs.metkit }}
-
+    - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: |-
+          ${{ inputs.metkit }}
+          ${{ inputs.eccodes }}
+          ${{ inputs.eckit }}
   metkit:
     name: metkit
-    needs: [setup, eckit, eccodes]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.metkit && (inputs.eckit || inputs.eccodes || inputs.metkit) }}
+    needs:
+    - eccodes
+    - eckit
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.metkit && (inputs.eccodes || inputs.eckit || inputs.metkit) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.metkit) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          build_dependencies: |
-            ${{ inputs.eccodes }}
-            ${{ inputs.eckit }}
-
+    - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: |-
+          ${{ inputs.eccodes }}
+          ${{ inputs.eckit }}
   mir:
     name: mir
-    needs: [setup, eckit, eccodes, atlas]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.mir && (inputs.eckit || inputs.eccodes || inputs.atlas || inputs.mir) }}
+    needs:
+    - atlas
+    - fckit
+    - eckit
+    - eccodes
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.mir && (inputs.atlas || inputs.fckit || inputs.eckit || inputs.eccodes || inputs.mir) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.mir) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          build_dependencies: |
-            ${{ inputs.eccodes }}
-            ${{ inputs.eckit }}
-            ${{ inputs.atlas }}
-
+    - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: |-
+          ${{ inputs.atlas }}
+          ${{ inputs.fckit }}
+          ${{ inputs.eckit }}
+          ${{ inputs.eccodes }}
   multiurl:
     name: multiurl
-    needs: [setup]
+    needs:
+    - setup
+    - python-qa
     if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.multiurl && (inputs.multiurl) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.multiurl) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-python@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          checkout: true
-  
-
+    - uses: ecmwf-actions/reusable-workflows/ci-python@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        checkout: true
+        python_dependencies: ''
   odc:
     name: odc
-    needs: [setup, eckit]
+    needs:
+    - eckit
+    - setup
     if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.odc && (inputs.eckit || inputs.odc) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.odc) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          build_dependencies: |
-            ${{ inputs.eckit }}
-
+    - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: ${{ inputs.eckit }}
   pdbufr:
     name: pdbufr
-    needs: [setup, eccodes, eccodes-python]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.pdbufr && (inputs.pdbufr || inputs.eccodes || inputs.eccodes-python) }}
+    needs:
+    - eccodes-python
+    - eccodes
+    - setup
+    - python-qa
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.pdbufr && (inputs.eccodes-python || inputs.eccodes || inputs.pdbufr) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.pdbufr) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - name: Build dependencies
-        id: build-deps
-        uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          build_dependencies: |
-            ${{ inputs.eccodes }}
-
-      - uses: ecmwf-actions/reusable-workflows/ci-python@v2
-        with:
-          lib_path: ${{ steps.build-deps.outputs.lib_path }}
-          python_dependencies: ${{ inputs.eccodes-python || 'ecmwf/eccodes-python@develop' }}
-          requirements_path: tests/downstream-ci-requirements.txt
-
+    - name: Build dependencies
+      id: build-deps
+      uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: ${{ inputs.eccodes }}
+    - uses: ecmwf-actions/reusable-workflows/ci-python@v2
+      with:
+        lib_path: ${{ steps.build-deps.outputs.lib_path }}
+        conda_install: libffi=3.3
+        python_dependencies: ${{ inputs.eccodes-python }}
   plume:
     name: plume
-    needs: [setup, eckit, fckit, atlas]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.plume && (inputs.eckit || inputs.fckit || inputs.atlas || inputs.plume) }}
+    needs:
+    - atlas
+    - fckit
+    - eckit
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.plume && (inputs.atlas || inputs.fckit || inputs.eckit || inputs.plume) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.plume) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          build_dependencies: |
-            ${{ inputs.eckit }}
-            ${{ inputs.fckit }}
-            ${{ inputs.atlas }}
-
+    - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: |-
+          ${{ inputs.atlas }}
+          ${{ inputs.fckit }}
+          ${{ inputs.eckit }}
   pyfdb:
     name: pyfdb
-    needs: [setup, eckit, eccodes, metkit, fdb]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.pyfdb && (inputs.eckit || inputs.eccodes || inputs.metkit || inputs.fdb || inputs.pyfdb) }}
+    needs:
+    - fdb
+    - metkit
+    - eccodes
+    - eckit
+    - setup
+    - python-qa
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.pyfdb && (inputs.fdb || inputs.metkit || inputs.eccodes || inputs.eckit || inputs.pyfdb) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.pyfdb) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - name: Build dependencies
-        id: build-deps
-        uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          build_dependencies: |
-            ${{ inputs.eccodes }}
-            ${{ inputs.eckit }}
-            ${{ inputs.metkit }}
-            ${{ inputs.fdb }}
-      - run: mkdir -p data/fdb
-      - uses: ecmwf-actions/reusable-workflows/ci-python@v2
-        env:
-          FDB5_CONFIG: >
-            {"type":"local","engine":"toc","schema":"${{ github.workspace }}/tests/default_fdb_schema","spaces":[{"handler":"Default","roots":[{"path":"${{ github.workspace }}/data/fdb"}]}]}
-        with:
-          lib_path: ${{ steps.build-deps.outputs.lib_path }}
-          conda_install: libffi=3.3
-
+    - name: Build dependencies
+      id: build-deps
+      uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: |-
+          ${{ inputs.fdb }}
+          ${{ inputs.metkit }}
+          ${{ inputs.eccodes }}
+          ${{ inputs.eckit }}
+    - uses: ecmwf-actions/reusable-workflows/ci-python@v2
+      with:
+        lib_path: ${{ steps.build-deps.outputs.lib_path }}
+        conda_install: libffi=3.3
+        python_dependencies: ''
   pyodc:
     name: pyodc
-    needs: [setup, eckit, odc]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.pyodc && (inputs.eckit || inputs.odc || inputs.pyodc) }}
+    needs:
+    - odc
+    - eckit
+    - setup
+    - python-qa
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.pyodc && (inputs.odc || inputs.eckit || inputs.pyodc) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.pyodc) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - name: Build dependencies
-        id: build-deps
-        uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          build_dependencies: |
-            ${{ inputs.eckit }}
-            ${{ inputs.odc}}
-
-      - uses: ecmwf-actions/reusable-workflows/ci-python@v2
-        with:
-          lib_path: ${{ steps.build-deps.outputs.lib_path }}
-          conda_install: libffi=3.3
-
+    - name: Build dependencies
+      id: build-deps
+      uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: |-
+          ${{ inputs.odc }}
+          ${{ inputs.eckit }}
+    - uses: ecmwf-actions/reusable-workflows/ci-python@v2
+      with:
+        lib_path: ${{ steps.build-deps.outputs.lib_path }}
+        conda_install: libffi=3.3
+        python_dependencies: ''
   skinnywms:
     name: skinnywms
-    needs: [setup]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.skinnywms && inputs.skinnywms }}
+    needs:
+    - setup
+    - python-qa
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.skinnywms && (inputs.skinnywms) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.skinnywms) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
     steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-python@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          checkout: true
-
+    - uses: ecmwf-actions/reusable-workflows/ci-python@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        checkout: true
+        python_dependencies: ''
   thermofeel:
     name: thermofeel
-    needs: [setup, python-qa]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.thermofeel && inputs.thermofeel }}
+    needs:
+    - setup
+    - python-qa
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.thermofeel && (inputs.thermofeel) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.thermofeel) }}
-    runs-on: ${{ matrix.labels }}
     env:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
-    steps:
-      - uses: ecmwf-actions/reusable-workflows/ci-python@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          checkout: true
-  
-  earthkit-data:
-    name: earthkit-data
-    needs: [setup, cfgrib, pdbufr, pyodc]
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.earthkit-data && (inputs.cfgrib || inputs.eccodes-python|| inputs.multiurl || inputs.pdbufr || inputs.pyodc || inputs.earthkit-data) }}
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.setup.outputs.earthkit-data) }}
     runs-on: ${{ matrix.labels }}
-    env:
-      DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
     steps:
-      - name: Build dependencies
-        id: build-deps
-        uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-        with:
-          repository: ${{ matrix.owner_repo_ref }}
-          codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
-          build_package_inputs: |
-            repository: ${{ matrix.owner_repo_ref }}
-          build_config: ${{ matrix.config_path }}
-          build_dependencies: |
-            ${{ inputs.eccodes }}
-
-      - uses: ecmwf-actions/reusable-workflows/ci-python@v2
-        with:
-          lib_path: ${{ steps.build-deps.outputs.lib_path }}
-          python_dependencies: |
-            ${{ inputs.cfgrib || 'ecmwf/cfgrib@master' }}
-            ${{ inputs.eccodes-python || 'ecmwf/eccodes-python@develop' }}
-            ${{ inputs.multiurl || 'ecmwf/multiurl@main' }}
-            ${{ inputs.pdbufr || 'ecmwf/pdbufr@master' }}
-            ${{ inputs.pyodc || 'ecmwf/pyodc@develop' }}
-          requirements_path: tests/downstream-ci-requirements.txt
-          test_cmd: |
-            python -m pytest -vv -m 'not notebook and not no_cache_init' --cov=. --cov-report=xml
-            python -m pytest -v -m 'notebook'
-            python -m pytest --forked -vv -m 'no_cache_init'
-            python -m coverage report
-
-  
+    - uses: ecmwf-actions/reusable-workflows/ci-python@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        checkout: true
+        python_dependencies: ''

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -492,6 +492,7 @@ jobs:
           ${{ inputs.pdbufr }}
           ${{ inputs.eccodes-python }}
           ${{ inputs.pyodc }}
+        requirements_path: tests/downstream-ci-requirements.txt
   eccodes:
     name: eccodes
     needs:
@@ -759,6 +760,7 @@ jobs:
         lib_path: ${{ steps.build-deps.outputs.lib_path }}
         conda_install: libffi=3.3
         python_dependencies: ${{ inputs.eccodes-python }}
+        requirements_path: tests/downstream-ci-requirements.txt
   plume:
     name: plume
     needs:

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -107,7 +107,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ecmwf-actions/downstream-ci
-        ref: main
+        ref: generate-workflow
     - name: Run setup script
       id: setup
       env:
@@ -119,120 +119,140 @@ jobs:
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.atlas }}
+            optional_matrix: null
           ecmwf/cfgrib:
             path: .github/ci-config.yml
             python: true
             master_branch: master
             develop_branch: master
             input: ${{ inputs.cfgrib }}
+            optional_matrix: null
           ecmwf/earthkit-data:
             path: .github/ci-config.yml
             python: true
             master_branch: main
             develop_branch: develop
             input: ${{ inputs.earthkit-data }}
+            optional_matrix: null
           ecmwf/eccodes:
             path: .github/ci-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.eccodes }}
+            optional_matrix: null
           ecmwf/eccodes-python:
             path: .github/ci-config.yml
             python: true
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.eccodes-python }}
+            optional_matrix: null
           ecmwf/ecflow:
             path: .github/ci-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.ecflow }}
+            optional_matrix: null
           ecmwf/ecflow-light:
             path: .github/ci-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.ecflow-light }}
+            optional_matrix: null
           ecmwf/eckit:
             path: .github/ci-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.eckit }}
+            optional_matrix: null
           ecmwf/fckit:
             path: .github/ci-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.fckit }}
+            optional_matrix: null
           ecmwf/fdb:
             path: .github/ci-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.fdb }}
+            optional_matrix: null
           ecmwf/metkit:
             path: .github/ci-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.metkit }}
+            optional_matrix: null
           ecmwf/mir:
             path: .github/ci-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.mir }}
+            optional_matrix: null
           ecmwf/multiurl:
             path: .github/ci-config.yml
             python: true
             master_branch: main
             develop_branch: main
             input: ${{ inputs.multiurl }}
+            optional_matrix: null
           ecmwf/odc:
             path: .github/ci-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.odc }}
+            optional_matrix: null
           ecmwf/pdbufr:
             path: .github/ci-config.yml
             python: true
             master_branch: master
             develop_branch: master
             input: ${{ inputs.pdbufr }}
+            optional_matrix: null
           ecmwf/plume:
             path: .github/ci-config.yml
             python: false
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.plume }}
+            optional_matrix: null
           ecmwf/pyfdb:
             path: .github/ci-config.yml
             python: true
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.pyfdb }}
+            optional_matrix: null
           ecmwf/pyodc:
             path: .github/ci-config.yml
             python: true
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.pyodc }}
+            optional_matrix: null
           ecmwf/skinnywms:
             path: .github/ci-config.yml
             python: true
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.skinnywms }}
+            optional_matrix: null
           ecmwf/thermofeel:
             path: .github/ci-config.yml
             python: true
             master_branch: master
             develop_branch: develop
             input: ${{ inputs.thermofeel }}
+            optional_matrix: null
         SKIP_MATRIX_JOBS: ${{ inputs.skip_matrix_jobs }}
         PYTHON_VERSIONS: |+
           - '3.10'
@@ -370,6 +390,9 @@ jobs:
           - gnu@fedora-37
           - clang@macos-13-arm
           - clang@macos-13-x86
+        OPTIONAL_MATRIX: |
+          null
+          ...
       run: python setup_downstream_ci.py
   python-qa:
     name: python-qa

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -115,127 +115,130 @@ jobs:
         CONFIG: |
           ecmwf/atlas:
             path: .github/ci-config.yml
-            input: ${{ inputs.atlas }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.atlas }}
           ecmwf/cfgrib:
             path: .github/ci-config.yml
-            input: ${{ inputs.cfgrib }}
             python: true
             master_branch: master
             develop_branch: master
+            input: ${{ inputs.cfgrib }}
           ecmwf/earthkit-data:
             path: .github/ci-config.yml
-            input: ${{ inputs.earthkit-data }}
             python: true
             master_branch: main
             develop_branch: develop
+            input: ${{ inputs.earthkit-data }}
           ecmwf/eccodes:
             path: .github/ci-config.yml
-            input: ${{ inputs.eccodes }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.eccodes }}
           ecmwf/eccodes-python:
             path: .github/ci-config.yml
-            input: ${{ inputs.eccodes-python }}
             python: true
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.eccodes-python }}
           ecmwf/ecflow:
             path: .github/ci-config.yml
-            input: ${{ inputs.ecflow }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.ecflow }}
           ecmwf/ecflow-light:
             path: .github/ci-config.yml
-            input: ${{ inputs.ecflow-light }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.ecflow-light }}
           ecmwf/eckit:
             path: .github/ci-config.yml
-            input: ${{ inputs.eckit }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.eckit }}
           ecmwf/fckit:
             path: .github/ci-config.yml
-            input: ${{ inputs.fckit }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.fckit }}
           ecmwf/fdb:
             path: .github/ci-config.yml
-            input: ${{ inputs.fdb }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.fdb }}
           ecmwf/metkit:
             path: .github/ci-config.yml
-            input: ${{ inputs.metkit }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.metkit }}
           ecmwf/mir:
             path: .github/ci-config.yml
-            input: ${{ inputs.mir }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.mir }}
           ecmwf/multiurl:
             path: .github/ci-config.yml
-            input: ${{ inputs.multiurl }}
             python: true
             master_branch: main
             develop_branch: main
+            input: ${{ inputs.multiurl }}
           ecmwf/odc:
             path: .github/ci-config.yml
-            input: ${{ inputs.odc }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.odc }}
           ecmwf/pdbufr:
             path: .github/ci-config.yml
-            input: ${{ inputs.pdbufr }}
             python: true
             master_branch: master
             develop_branch: master
+            input: ${{ inputs.pdbufr }}
           ecmwf/plume:
             path: .github/ci-config.yml
-            input: ${{ inputs.plume }}
             python: false
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.plume }}
           ecmwf/pyfdb:
             path: .github/ci-config.yml
-            input: ${{ inputs.pyfdb }}
             python: true
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.pyfdb }}
           ecmwf/pyodc:
             path: .github/ci-config.yml
-            input: ${{ inputs.pyodc }}
             python: true
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.pyodc }}
           ecmwf/skinnywms:
             path: .github/ci-config.yml
-            input: ${{ inputs.skinnywms }}
             python: true
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.skinnywms }}
           ecmwf/thermofeel:
             path: .github/ci-config.yml
-            input: ${{ inputs.thermofeel }}
             python: true
             master_branch: master
             develop_branch: develop
+            input: ${{ inputs.thermofeel }}
         SKIP_MATRIX_JOBS: ${{ inputs.skip_matrix_jobs }}
         PYTHON_VERSIONS: |+
           - '3.10'
+
+        PYTHON_JOBS: |+
+          []
 
         MATRIX: |
           include:

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -493,6 +493,11 @@ jobs:
           ${{ inputs.eccodes-python }}
           ${{ inputs.pyodc }}
         requirements_path: tests/downstream-ci-requirements.txt
+        test_cmd: |
+          python -m pytest -vv -m 'not notebook and not no_cache_init' --cov=. --cov-report=xml
+          python -m pytest -v -m 'notebook'
+          python -m pytest --forked -vv -m 'no_cache_init'
+          python -m coverage report
   eccodes:
     name: eccodes
     needs:

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -107,7 +107,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ecmwf-actions/downstream-ci
-        ref: generate-workflow
+        ref: main
     - name: Run setup script
       id: setup
       env:

--- a/.github/workflows/generate-workflows.yml
+++ b/.github/workflows/generate-workflows.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           python-version: "3.x"
 
+      - run: pip install pyyaml
+
       - name: Build
         run: python generate-workflows.py --config config.yml --dep-tree dependency_tree.yml --output .github/workflows
 

--- a/.github/workflows/generate-workflows.yml
+++ b/.github/workflows/generate-workflows.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref  }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.REBUILD_PUSH_TOKEN }}
 
       - name: Git config
         run: |

--- a/.github/workflows/generate-workflows.yml
+++ b/.github/workflows/generate-workflows.yml
@@ -1,0 +1,45 @@
+# This workflows generates downstream-ci workflows on every push.
+# If you wish to skip the build, e.g. for testing manual changes add `[skip ci]` to commit msg.
+name: Generate workflows
+
+on: push
+
+jobs:
+  generate:
+    if: github.actor != 'github-actions[bot]' && !github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref  }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Git config
+        run: |
+          git config --global user.email "github-actions@example.com"
+          git config --global user.name "github-actions[bot]"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build
+        run: python generate-workflows.py --config config.yml --dep-tree dependency_tree.yml --output .github/workflows
+
+      - name: Check Git status
+        id: git_status
+        run: |
+          GIT_STATUS_OUTPUT=$(git status --porcelain)
+          if [[ -n "$GIT_STATUS_OUTPUT" ]]; then
+            echo "GIT_STATUS_MODIFIED=true" >> $GITHUB_ENV
+          else
+            echo "GIT_STATUS_MODIFIED=false" >> $GITHUB_ENV
+          fi
+
+      - name: Commit & push index.js
+        # Push only if the built workflow has changed.
+        if: env.GIT_STATUS_MODIFIED == 'true'
+        run: |
+          git add .github/workflows/*
+          git commit --no-verify -m "Build workflows"
+          git push origin ${{ github.head_ref || github.ref  }}

--- a/config.yml
+++ b/config.yml
@@ -116,24 +116,28 @@ downstream-ci-hpc:
       - intel-2021.4.0
     include:
       - name: gnu-12.2.0
+        site: atos
         compiler: gnu-12.2.0
         compiler_cc: gcc
         compiler_cxx: g++
         compiler_fc: gfortran
         compiler_modules: gcc/12.2.0
       - name: gnu-8.5.0
+        site: atos
         compiler: gnu-8.5.0
         compiler_cc: gcc
         compiler_cxx: g++
         compiler_fc: gfortran
         compiler_modules: gcc/8.5.0
       - name: nvidia-22.11
+        site: atos
         compiler: nvidia-22.11
         compiler_cc: nvc
         compiler_cxx: nvc++
         compiler_fc: nvfortran
         compiler_modules: prgenv/nvidia,nvidia/22.11
       - name: intel-2021.4.0
+        site: atos
         compiler: intel-2021.4.0
         compiler_cc: icc
         compiler_cxx: icpc
@@ -143,7 +147,8 @@ downstream-ci-hpc:
     name:
       - lumi
     include:
-      - name: lumi
+      - name: lumi-gnu-12.2.0
+        site: lumi
         compiler: gnu-12.2.0
         compiler_cc: gcc
         compiler_cxx: g++

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,10 @@
 downstream-ci:
   type: build-package
+  inputs:
+    codecov_upload:
+      description: Whether to upload code coverage
+      type: boolean
+      required: false
   python_qa: true
   python_versions:
     - "3.10"
@@ -98,6 +103,11 @@ downstream-ci:
         env: *macos_env
 downstream-ci-hpc:
   type: build-package-hpc
+  inputs:
+    dev_runner:
+      description: Whether to use runner with dev version of build-package-hpc .
+      required: false
+      type: boolean
   python_versions:
     - "3.10"
   matrix:

--- a/config.yml
+++ b/config.yml
@@ -103,11 +103,6 @@ downstream-ci:
         env: *macos_env
 downstream-ci-hpc:
   type: build-package-hpc
-  inputs:
-    dev_runner:
-      description: Whether to use runner with dev version of build-package-hpc .
-      required: false
-      type: boolean
   python_versions:
     - "3.10"
   matrix:

--- a/config.yml
+++ b/config.yml
@@ -101,6 +101,7 @@ downstream-ci:
         compiler_fc: gfortran
         #OPENSSL_ROOT_DIR is taken care of in build-package
         env: *macos_env
+  optional_matrix: null
 downstream-ci-hpc:
   type: build-package-hpc
   python_jobs:
@@ -138,3 +139,13 @@ downstream-ci-hpc:
         compiler_cxx: icpc
         compiler_fc: ifort
         compiler_modules: prgenv/intel,intel/2021.4.0
+  optional_matrix:
+    name:
+      - lumi
+    include:
+      - name: lumi
+        compiler: gnu-12.2.0
+        compiler_cc: gcc
+        compiler_cxx: g++
+        compiler_fc: gfortran
+        compiler_modules: LUMI/23.09,cpeGNU/23.09

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,133 @@
+downstream-ci:
+  type: build-package
+  python_qa: true
+  python_versions:
+    - "3.10"
+  matrix:
+    name:
+      - gnu@debian-11
+      - gnu-7@centos-7.9
+      - gnu-8@centos-7.9
+      - gnu@rocky-8.6
+      - clang@rocky-8.6
+      - gnu@ubuntu-22.04
+      - gnu@fedora-37
+      - clang@macos-13-arm
+      - clang@macos-13-x86
+    include:
+      - name: gnu@debian-11
+        labels: [self-hosted, platform-builder-debian-11]
+        os: debian-11
+        compiler: gnu
+        compiler_cc: gcc
+        compiler_cxx: g++
+        compiler_fc: gfortran
+        env: &linux_env |
+          BOOST_ROOT_DIR=/usr
+          BOOST_INCLUDE_DIR=/usr/include/boost169
+          BOOST_LIB_DIR=/usr/lib64/boost169
+      - name: gnu-7@centos-7.9
+        labels: [self-hosted, platform-builder-centos-7.9]
+        os: centos-7.9
+        compiler: gnu-7
+        compiler_cc: gcc-7
+        compiler_cxx: g++-7
+        compiler_fc: gfortran-7
+        env: *linux_env
+      - name: gnu-8@centos-7.9
+        labels: [self-hosted, platform-builder-centos-7.9]
+        os: centos-7.9
+        compiler: gnu-8
+        compiler_cc: gcc-8
+        compiler_cxx: g++-8
+        compiler_fc: gfortran-8
+        env: *linux_env
+      - name: gnu@rocky-8.6
+        labels: [self-hosted, platform-builder-rocky-8.6]
+        os: rocky-8.6
+        compiler: gnu
+        compiler_cc: gcc
+        compiler_cxx: g++
+        compiler_fc: gfortran
+        env: *linux_env
+      - name: clang@rocky-8.6
+        labels: [self-hosted, platform-builder-rocky-8.6]
+        os: rocky-8.6
+        compiler: clang
+        compiler_cc: clang
+        compiler_cxx: clang++
+        compiler_fc: gfortran
+        env: *linux_env
+        toolchain_file: /opt/actions-runner/files/toolchain-clang-rocky-8.6.cmake
+      - name: gnu@ubuntu-22.04
+        labels: [self-hosted, platform-builder-ubuntu-22.04]
+        os: ubuntu-22.04
+        compiler: gnu
+        compiler_cc: gcc
+        compiler_cxx: g++
+        compiler_fc: gfortran
+        env: *linux_env
+      - name: gnu@fedora-37
+        labels: [self-hosted, platform-builder-fedora-37]
+        os: fedora-37
+        compiler: gnu
+        compiler_cc: gcc
+        compiler_cxx: g++
+        compiler_fc: gfortran
+        env: *linux_env
+      - name: clang@macos-13-arm
+        labels: [self-hosted, platform-builder-macosx-13.4.1-arm64]
+        os: macos-13-arm
+        compiler: clang
+        compiler_cc: clang
+        compiler_cxx: clang++
+        compiler_fc: gfortran
+        #OPENSSL_ROOT_DIR is taken care of in build-package
+        env: &macos_env |
+          BOOST_ROOT_DIR=$(brew --prefix)
+          BOOST_INCLUDE_DIR=$(brew --prefix)/include
+          BOOST_LIB_DIR=$(brew --prefix)/lib
+      - name: clang@macos-13-x86
+        labels: [self-hosted, platform-builder-macosx-13.4.1-x86_64]
+        os: macos-13-x86
+        compiler: clang
+        compiler_cc: clang
+        compiler_cxx: clang++
+        compiler_fc: gfortran
+        #OPENSSL_ROOT_DIR is taken care of in build-package
+        env: *macos_env
+downstream-ci-hpc:
+  type: build-package-hpc
+  python_versions:
+    - "3.10"
+  matrix:
+    name:
+      - gnu-12.2.0
+      - gnu-8.5.0
+      - nvidia-22.11
+      - intel-2021.4.0
+    include:
+      - name: gnu-12.2.0
+        compiler: gnu-12.2.0
+        compiler_cc: gcc
+        compiler_cxx: g++
+        compiler_fc: gfortran
+        compiler_modules: gcc/12.2.0
+      - name: gnu-8.5.0
+        compiler: gnu-8.5.0
+        compiler_cc: gcc
+        compiler_cxx: g++
+        compiler_fc: gfortran
+        compiler_modules: gcc/8.5.0
+      - name: nvidia-22.11
+        compiler: nvidia-22.11
+        compiler_cc: nvc
+        compiler_cxx: nvc++
+        compiler_fc: nvfortran
+        compiler_modules: prgenv/nvidia,nvidia/22.11
+      - name: intel-2021.4.0
+        compiler: intel-2021.4.0
+        compiler_cc: icc
+        compiler_cxx: icpc
+        compiler_fc: ifort
+        compiler_modules: prgenv/intel,intel/2021.4.0

--- a/config.yml
+++ b/config.yml
@@ -103,6 +103,8 @@ downstream-ci:
         env: *macos_env
 downstream-ci-hpc:
   type: build-package-hpc
+  python_jobs:
+    - gnu-8.5.0
   python_versions:
     - "3.10"
   matrix:

--- a/dependency_tree.yml
+++ b/dependency_tree.yml
@@ -1,182 +1,135 @@
----
-# this document is for build-package
-name: build-package
-
 atlas:
+  type: cmake
+  downstream-ci-hpc:
+    modules:
+      - fftw
+      - qhull
   deps:
     - eckit
     - fckit
 
 cfgrib:
+  type: python
+  master_branch: master
+  develop_branch: master
   deps:
     - eccodes-python
 
-ecbuild: ~
+earthkit-data:
+  type: python
+  master_branch: main
+  deps:
+    - cfgrib
+    - multiurl
+    - pdbufr
+    - pyodc
+
+ecbuild:
+  type: cmake
+  input: false
 
 eccodes:
-  deps:
-    - libaec
-    - ecbuild
+  type: cmake
+  downstream-ci-hpc:
+    modules:
+      - aec
+    deps:
+      - ecbuild
+  downstream-ci:
+    deps:
+      - libaec
+      - ecbuild
 
 eccodes-python:
+  type: python
   deps:
     - eccodes
 
 ecflow:
+  type: cmake
   deps:
     - ecbuild
 
 ecflow-light:
+  type: cmake
   deps:
     - eckit
 
 eckit:
+  type: cmake
   deps:
     - ecbuild
 
 fckit:
+  type: cmake
   deps:
     - eckit
 
 fdb:
+  type: cmake
   deps:
     - metkit
 
 libaec:
+  type: cmake
+  input: false
   deps:
     - ecbuild
 
 metkit:
+  type: cmake
   deps:
     - eccodes
     - eckit
 
 mir:
+  type: cmake
   deps:
     - atlas
     - eccodes
 
+multiurl:
+  type: python
+  master_branch: main
+  develop_branch: main
+
 odc:
+  type: cmake
   deps:
     - eckit
 
 pdbufr:
+  type: python
+  master_branch: master
+  develop_branch: master
   deps:
     - eccodes-python
 
 pgen:
+  type: cmake
+  input: false
   deps:
     - mir
     - metkit
 
 plume:
-  deps:
-    - atlas
-    - fckit
-pyfdb:
-  deps:
-    - fdb
-pyodc:
-  deps:
-    - odc
-earthkit-data:
-  deps:
-    - cfgrib
-    - multiurl
-    - pdbufr
-    - pyodc
-
----
-# this is for build-package-hpc
-name: build-package-hpc
-
-atlas:
-  modules:
-    - fftw
-    - qhull
-  deps:
-    - eckit
-    - fckit
-
-cfgrib:
-  deps:
-    - eccodes-python
-
-ecbuild: ~
-
-eccodes:
-  modules:
-    - aec
-
-eccodes-python:
-  deps:
-    - eccodes
-
-ecflow:
-  deps:
-    - ecbuild
-
-ecflow-light:
-  deps:
-    - eckit
-
-eckit:
-  deps:
-    - ecbuild
-
-fckit:
-  deps:
-    - eckit
-
-fdb:
-  deps:
-    - metkit
-
-metkit:
-  deps:
-    - eccodes
-    - eckit
-
-multiurl: ~
-
-mir:
-  deps:
-    - atlas
-    - eccodes
-
-odc:
-  deps:
-    - eckit
-
-pdbufr:
-  deps:
-    - eccodes-python
-
-pgen:
-  deps:
-    - mir
-    - metkit
-
-plume:
+  type: cmake
   deps:
     - atlas
     - fckit
 
 pyfdb:
+  type: python
   deps:
     - fdb
 
 pyodc:
+  type: python
   deps:
     - odc
 
-skinnywms: ~
+skinnywms:
+  type: python
 
-thermofeel: ~
-
-earthkit-data:
-  deps:
-    - cfgrib
-    - multiurl
-    - pdbufr
-    - pyodc
+thermofeel:
+  type: python

--- a/dependency_tree.yml
+++ b/dependency_tree.yml
@@ -24,6 +24,12 @@ earthkit-data:
     - multiurl
     - pdbufr
     - pyodc
+  downstream-ci:
+    test_cmd: |
+      python -m pytest -vv -m 'not notebook and not no_cache_init' --cov=. --cov-report=xml
+      python -m pytest -v -m 'notebook'
+      python -m pytest --forked -vv -m 'no_cache_init'
+      python -m coverage report
 
 ecbuild:
   type: cmake

--- a/dependency_tree.yml
+++ b/dependency_tree.yml
@@ -18,6 +18,7 @@ cfgrib:
 earthkit-data:
   type: python
   master_branch: main
+  requirements_path: tests/downstream-ci-requirements.txt
   deps:
     - cfgrib
     - multiurl
@@ -102,6 +103,7 @@ pdbufr:
   type: python
   master_branch: master
   develop_branch: master
+  requirements_path: tests/downstream-ci-requirements.txt
   deps:
     - eccodes-python
 

--- a/generate-workflows.py
+++ b/generate-workflows.py
@@ -364,6 +364,9 @@ class Workflow:
                     )
                     or "develop",
                     "input": "${{ " + f"inputs.{dep}" + " }}",
+                    "optional_matrix": tree_get_package_var(
+                        "optional_matrix", dep_tree, dep, self.name
+                    ),
                 }
         steps.append(
             {
@@ -389,6 +392,9 @@ class Workflow:
                     )
                     + "\n",
                     "MATRIX": yaml.dump(wf_config["matrix"], indent=2),
+                    "OPTIONAL_MATRIX": yaml.dump(
+                        wf_config["optional_matrix"], indent=2, default_flow_style=False
+                    ),
                 },
                 "run": "python setup_downstream_ci.py",
             }

--- a/generate-workflows.py
+++ b/generate-workflows.py
@@ -140,7 +140,10 @@ class Workflow:
             },
             {
                 "name": "Install Python Dependencies",
-                "run": "python -m pip install --upgrade pip\npython -m pip install black flake8 isort\n",
+                "run": (
+                    "python -m pip install --upgrade pip\n"
+                    "python -m pip install black flake8 isort\n"
+                ),
             },
             {"name": "Check isort", "run": "isort --check ."},
             {"name": "Check black", "run": "black --check ."},
@@ -191,11 +194,19 @@ class Workflow:
                 if pkg_conf.get("type", "cmake") == "cmake":
                     steps.append(
                         {
-                            "uses": "ecmwf-actions/reusable-workflows/build-package-with-config@v2",
+                            "uses": (
+                                "ecmwf-actions/reusable-workflows/"
+                                "build-package-with-config@v2"
+                            ),
                             "with": {
                                 "repository": "${{ matrix.owner_repo_ref }}",
-                                "codecov_upload": "${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}",
-                                "build_package_inputs": "repository: ${{ matrix.owner_repo_ref }}",
+                                "codecov_upload": (
+                                    "${{ needs.setup.outputs.trigger_repo "
+                                    "== github.job && inputs.codecov_upload }}"
+                                ),
+                                "build_package_inputs": (
+                                    "repository: ${{ matrix.owner_repo_ref }}"
+                                ),
                                 "build_config": "${{ matrix.config_path }}",
                                 "build_dependencies": build_deps,
                             },
@@ -209,11 +220,19 @@ class Workflow:
                             {
                                 "name": "Build dependencies",
                                 "id": "build-deps",
-                                "uses": "ecmwf-actions/reusable-workflows/build-package-with-config@v2",
+                                "uses": (
+                                    "ecmwf-actions/reusable-workflows/"
+                                    "build-package-with-config@v2"
+                                ),
                                 "with": {
                                     "repository": "${{ matrix.owner_repo_ref }}",
-                                    "codecov_upload": "${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}",
-                                    "build_package_inputs": "repository: ${{ matrix.owner_repo_ref }}",
+                                    "codecov_upload": (
+                                        "${{ needs.setup.outputs.trigger_repo == "
+                                        "github.job && inputs.codecov_upload }}"
+                                    ),
+                                    "build_package_inputs": (
+                                        "repository: ${{ matrix.owner_repo_ref }}"
+                                    ),
                                     "build_config": "${{ matrix.config_path }}",
                                     "build_dependencies": "\n".join(
                                         [
@@ -232,7 +251,9 @@ class Workflow:
                             {
                                 "uses": "ecmwf-actions/reusable-workflows/ci-python@v2",
                                 "with": {
-                                    "lib_path": "${{ steps.build-deps.outputs.lib_path }}",
+                                    "lib_path": (
+                                        "${{ steps.build-deps.outputs.lib_path }}"
+                                    ),
                                     "conda_install": "libffi=3.3",
                                     "python_dependencies": "\n".join(
                                         [
@@ -262,14 +283,20 @@ class Workflow:
                             }
                         )
             if self.wf_type == "build-package-hpc":
-                runs_on = "[self-hosted, linux, \"${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}\"]"
+                runs_on = [
+                    "self-hosted",
+                    "linux",
+                    "hpc",
+                ]
                 steps.append(
                     {
                         "uses": "ecmwf-actions/reusable-workflows/ci-hpc@v2",
                         "with": {
-                            "github_user": "${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}",
+                            "github_user": (
+                                "${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}"
+                            ),
                             "github_token": "${{ secrets.GH_REPO_READ_TOKEN }}",
-                            "troika_user": "${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}",
+                            "troika_user": "${{ secrets.HPC_CI_SSH_USER }}",
                             "repository": "${{ matrix.owner_repo_ref }}",
                             "build_config": "${{ matrix.config_path }}",
                             "dependencies": "\n".join(
@@ -372,7 +399,10 @@ def main():
     )
     parser.add_argument(
         "--output",
-        help="Path to output directory. Workflow files will be created/overwritten there.",
+        help=(
+            "Path to output directory. "
+            "Workflow files will be created/overwritten there."
+        ),
         required=True,
     )
     args = parser.parse_args()

--- a/generate-workflows.py
+++ b/generate-workflows.py
@@ -245,30 +245,36 @@ class Workflow:
                                 },
                             }
                         )
-                        steps.append(
-                            {
-                                "uses": "ecmwf-actions/reusable-workflows/ci-python@v2",
-                                "with": {
-                                    "lib_path": (
-                                        "${{ steps.build-deps.outputs.lib_path }}"
-                                    ),
-                                    "conda_install": "libffi=3.3",
-                                    "python_dependencies": "\n".join(python_deps),
-                                },
-                            }
-                        )
+                        ci_python_step = {
+                            "uses": "ecmwf-actions/reusable-workflows/ci-python@v2",
+                            "with": {
+                                "lib_path": (
+                                    "${{ steps.build-deps.outputs.lib_path }}"
+                                ),
+                                "conda_install": "libffi=3.3",
+                                "python_dependencies": "\n".join(python_deps),
+                            },
+                        }
+                        if pkg_conf.get("requirements_path"):
+                            ci_python_step["with"]["requirements_path"] = pkg_conf.get(
+                                "requirements_path"
+                            )
+                        steps.append(ci_python_step)
                     else:
                         # pure python package
-                        steps.append(
-                            {
-                                "uses": "ecmwf-actions/reusable-workflows/ci-python@v2",
-                                "with": {
-                                    "repository": "${{ matrix.owner_repo_ref }}",
-                                    "checkout": True,
-                                    "python_dependencies": "\n".join(python_deps),
-                                },
-                            }
-                        )
+                        ci_python_step = {
+                            "uses": "ecmwf-actions/reusable-workflows/ci-python@v2",
+                            "with": {
+                                "repository": "${{ matrix.owner_repo_ref }}",
+                                "checkout": True,
+                                "python_dependencies": "\n".join(python_deps),
+                            },
+                        }
+                        if pkg_conf.get("requirements_path"):
+                            ci_python_step["with"]["requirements_path"] = pkg_conf.get(
+                                "requirements_path"
+                            )
+                        steps.append(ci_python_step)
             if self.wf_type == "build-package-hpc":
                 runs_on = [
                     "self-hosted",

--- a/generate-workflows.py
+++ b/generate-workflows.py
@@ -338,7 +338,6 @@ class Workflow:
                         "config_path", dep_tree, dep, self.name
                     )
                     or default_config_path,
-                    "input": "${{ " + f"inputs.{dep}" + " }}",
                     "python": dep_tree[dep].get("type", "cmake") == "python",
                     "master_branch": tree_get_package_var(
                         "master_branch", dep_tree, dep, self.name
@@ -348,6 +347,7 @@ class Workflow:
                         "develop_branch", dep_tree, dep, self.name
                     )
                     or "develop",
+                    "input": "${{ " + f"inputs.{dep}" + " }}",
                 }
         steps.append(
             {
@@ -364,6 +364,12 @@ class Workflow:
                     "SKIP_MATRIX_JOBS": "${{ inputs.skip_matrix_jobs }}",
                     "PYTHON_VERSIONS": yaml.dump(
                         wf_config["python_versions"], indent=2, default_flow_style=False
+                    )
+                    + "\n",
+                    "PYTHON_JOBS": yaml.dump(
+                        wf_config.get("python_jobs", []),
+                        indent=2,
+                        default_flow_style=False,
                     )
                     + "\n",
                     "MATRIX": yaml.dump(wf_config["matrix"], indent=2),

--- a/generate-workflows.py
+++ b/generate-workflows.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python
+
+import argparse
+from pathlib import PurePath
+from typing import Literal
+import yaml
+
+from dataclasses import dataclass, field
+
+
+# modify how pyyaml dumps multiline strings - we want `|`
+def str_presenter(dumper, data):
+    if len(data.splitlines()) > 1:  # check for multiline string
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+yaml.add_representer(str, str_presenter)
+yaml.emitter.Emitter.prepare_tag = lambda self, tag: ""
+
+
+def get_package_deps(
+    package: str, dep_tree: dict, wf_name: str, deps: list[str] = None
+):
+    if deps is None:
+        deps = []
+    if package not in dep_tree or dep_tree[package] is None:
+        return deps
+
+    direct_deps = (
+        dep_tree[package].get(wf_name, {}).get("deps")
+        or dep_tree[package].get("deps")
+        or []
+    )
+
+    for dep in direct_deps:
+        if dep in deps:
+            deps.remove(dep)
+        deps.append(dep)
+        if dep in dep_tree:
+            get_package_deps(dep, dep_tree, wf_name, deps)
+
+    return deps
+
+
+def tree_get_package_var(var_name: str, dep_tree: dict, package: str, wf_name: str):
+    """Get package variable from dep tree. Prefers vars set for given workflow name."""
+    package_conf = dep_tree[package].get(wf_name) or dep_tree[package]
+    return package_conf.get(var_name)
+
+
+def get_type_deps(
+    package: str, dep_tree: dict, wf_name, type: Literal["cmake", "python"]
+):
+    package_deps = get_package_deps(package, dep_tree, wf_name)
+    type_deps = []
+    for dep in package_deps:
+        if dep_tree[dep].get("type", "cmake") == type:
+            type_deps.append(dep)
+    return type_deps
+
+
+@dataclass
+class Job:
+    name: str
+    needs: str | list[str] = None
+    condition: str = None
+    strategy: dict = None
+    env: dict = None
+    runs_on: str | list[str] = "ubuntu-latest"
+    steps: list[dict] = field(default_factory=list)
+    outputs: dict = None
+
+    def __getstate__(self) -> object:
+        d = {"name": self.name}
+        if self.needs:
+            d["needs"] = self.needs
+        if self.condition:
+            d["if"] = self.condition
+        if self.strategy:
+            d["strategy"] = self.strategy
+        if self.env:
+            d["env"] = self.env
+        d["runs-on"] = self.runs_on
+        if self.outputs:
+            d["outputs"] = self.outputs
+        d["steps"] = self.steps
+
+        return d
+
+
+@dataclass
+class Workflow:
+    name: str
+    wf_type: Literal["build-package", "build-package-hpc"]
+    inputs: dict = field(default_factory=dict)
+    jobs: dict[str, Job] = field(default_factory=dict)
+
+    def add_job(self, job: Job):
+        self.jobs[job.name] = job
+
+    # generate inputs - runner type specific inputs + list of packages
+    #   read config for specific inputs and dep tree for packages
+    def generate_inputs(self, dep_tree: dict):
+        for package, val in dep_tree.items():
+            if tree_get_package_var("input", dep_tree, package, self.name) is not False:
+                self.inputs[package] = {"required": False, "type": "string"}
+
+    def __getstate__(self) -> object:
+        d = {
+            "name": self.name,
+            "on": {"workflow_call": {"inputs": self.inputs}},
+            "jobs": self.jobs,
+        }
+        return d
+
+    def add_python_qa_job(self):
+        self.inputs["python_qa"] = {
+            "description": "Whether to run code QA tasks.",
+            "type": "boolean",
+            "required": False,
+        }
+
+        steps = [
+            {
+                "name": "Checkout Repository",
+                "uses": "actions/checkout@v4",
+                "with": {
+                    "repository": "${{ inputs.repository }}",
+                    "ref": "${{ inputs.ref }}",
+                },
+            },
+            {
+                "name": "Setup Python",
+                "uses": "actions/setup-python@v4",
+                "with": {"python-version": "3.x"},
+            },
+            {
+                "name": "Install Python Dependencies",
+                "run": "python -m pip install --upgrade pip\npython -m pip install black flake8 isort\n",
+            },
+            {"name": "Check isort", "run": "isort --check ."},
+            {"name": "Check black", "run": "black --check ."},
+            {"name": "Check flake8", "run": "flake8 ."},
+        ]
+
+        job = Job(
+            name="python-qa",
+            needs=["setup"],
+            condition="${{ inputs.python_qa }}",
+            steps=steps,
+        )
+        self.add_job(job)
+
+    def generate_package_jobs(self, dep_tree: dict):
+        for package, pkg_conf in dep_tree.items():
+            if tree_get_package_var("input", dep_tree, package, self.name) is False:
+                continue
+            package_deps = get_package_deps(package, dep_tree, self.name)
+            cmake_deps = get_type_deps(package, dep_tree, self.name, "cmake")
+            python_deps = get_type_deps(package, dep_tree, self.name, "python")
+            needs = [
+                dep
+                for dep in package_deps
+                if tree_get_package_var("input", dep_tree, dep, self.name) is not False
+            ]
+            condition_inputs = " || ".join(
+                [f"inputs.{dep}" for dep in needs + [package]]
+            )
+            build_deps = "\n".join(["${{ " + f"inputs.{dep}" + " }}" for dep in needs])
+            needs.append("setup")
+
+            condition = (
+                "${{ (always() && !cancelled()) "
+                "&& contains(join(needs.*.result, ','), 'success') "
+                f"&& needs.setup.outputs.{package} "
+                f"&& ({condition_inputs})"
+                " }}"
+            )
+            strategy = {
+                "fail-fast": False,
+                "matrix": "${{ " + f"fromJson(needs.setup.outputs.{package})" + " }}",
+            }
+            runs_on = "${{ matrix.labels }}"
+            env = {"DEP_TREE": "${{ needs.setup.outputs.dep_tree }}"}
+            steps = []
+            if self.wf_type == "build-package":
+                if pkg_conf.get("type", "cmake") == "cmake":
+                    steps.append(
+                        {
+                            "uses": "ecmwf-actions/reusable-workflows/build-package-with-config@v2",
+                            "with": {
+                                "repository": "${{ matrix.owner_repo_ref }}",
+                                "codecov_upload": "${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}",
+                                "build_package_inputs": "repository: ${{ matrix.owner_repo_ref }}",
+                                "build_config": "${{ matrix.config_path }}",
+                                "build_dependencies": build_deps,
+                            },
+                        }
+                    )
+                if pkg_conf.get("type", "cmake") == "python":
+                    needs.append("python-qa")
+                    if len(cmake_deps):
+                        # python package with cmake deps
+                        steps.append(
+                            {
+                                "name": "Build dependencies",
+                                "id": "build-deps",
+                                "uses": "ecmwf-actions/reusable-workflows/build-package-with-config@v2",
+                                "with": {
+                                    "repository": "${{ matrix.owner_repo_ref }}",
+                                    "codecov_upload": "${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}",
+                                    "build_package_inputs": "repository: ${{ matrix.owner_repo_ref }}",
+                                    "build_config": "${{ matrix.config_path }}",
+                                    "build_dependencies": "\n".join(
+                                        [
+                                            "${{ " + f"inputs.{dep}" + " }}"
+                                            for dep in cmake_deps
+                                            if tree_get_package_var(
+                                                "input", dep_tree, dep, self.name
+                                            )
+                                            is not False
+                                        ],
+                                    ),
+                                },
+                            }
+                        )
+                        steps.append(
+                            {
+                                "uses": "ecmwf-actions/reusable-workflows/ci-python@v2",
+                                "with": {
+                                    "lib_path": "${{ steps.build-deps.outputs.lib_path }}",
+                                    "conda_install": "libffi=3.3",
+                                    "python_dependencies": "\n".join(
+                                        [
+                                            "${{ " + f"inputs.{dep}" + " }}"
+                                            for dep in python_deps
+                                            if tree_get_package_var(
+                                                "input", dep_tree, dep, self.name
+                                            )
+                                            is not False
+                                        ]
+                                    ),
+                                },
+                            }
+                        )
+                    else:
+                        # pure python package
+                        steps.append(
+                            {
+                                "uses": "ecmwf-actions/reusable-workflows/ci-python@v2",
+                                "with": {
+                                    "repository": "${{ matrix.owner_repo_ref }}",
+                                    "checkout": True,
+                                    "python_dependencies": "\n".join(
+                                        [f"inputs.{dep}" for dep in python_deps]
+                                    ),
+                                },
+                            }
+                        )
+            if self.wf_type == "build-package-hpc":
+                runs_on = "[self-hosted, linux, \"${{ inputs.dev_runner && 'hpc-dev' || 'hpc' }}\"]"
+                steps.append(
+                    {
+                        "uses": "ecmwf-actions/reusable-workflows/ci-hpc@v2",
+                        "with": {
+                            "github_user": "${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}",
+                            "github_token": "${{ secrets.GH_REPO_READ_TOKEN }}",
+                            "troika_user": "${{ inputs.dev_runner && secrets.HPC_DEV_CI_SSH_USER || secrets.HPC_CI_SSH_USER }}",
+                            "repository": "${{ matrix.owner_repo_ref }}",
+                            "build_config": "${{ matrix.config_path }}",
+                            "dependencies": "\n".join(
+                                [f"inputs.{dep}" for dep in cmake_deps]
+                            ),
+                            "python_dependencies": "\n".join(
+                                [f"inputs.{dep}" for dep in python_deps]
+                            ),
+                        },
+                    }
+                )
+            self.add_job(Job(package, needs, condition, strategy, env, runs_on, steps))
+
+    def generate_setup_job(self, dep_tree: dict, wf_config: dict):
+        outputs = {}
+        for dep in dep_tree:
+            if tree_get_package_var("input", dep_tree, dep, self.name) is not False:
+                outputs[dep] = "${{ " + f"steps.setup.outputs.{dep}" + " }}"
+        if self.wf_type == "build-package":
+            outputs["dep_tree"] = "${{ steps.setup.outputs.build_package_dep_tree }}"
+            outputs["trigger_repo"] = "${{ steps.setup.outputs.trigger_repo }}"
+            outputs["py_codecov_platform"] = (
+                "${{ steps.setup.outputs.py_codecov_platform }}"
+            )
+        elif self.wf_type == "build-package-hpc":
+            outputs["dep_tree"] = (
+                "${{ steps.setup.outputs.build_package_hpc_dep_tree }}"
+            )
+        steps = []
+        steps.append(
+            {
+                "name": "checkout reusable wfs repo",
+                "uses": "actions/checkout@v4",
+                "with": {"repository": "ecmwf-actions/downstream-ci", "ref": "main"},
+            }
+        )
+        steps.append(
+            {
+                "name": "Run setup script",
+                "id": "setup",
+                "env": {
+                    "TOKEN": "${{ secrets.GH_REPO_READ_TOKEN }}",
+                    "CONFIG": "",
+                    "SKIP_MATRIX_JOBS": "${{ inputs.skip_matrix_jobs }}",
+                    "PYTHON_VERSIONS": yaml.dump(
+                        wf_config["python_versions"], indent=2, default_flow_style=False
+                    )
+                    + "\n",
+                    "MATRIX": yaml.dump(wf_config["matrix"], indent=2),
+                },
+                "run": "python setup_downstream_ci.py",
+            }
+        )
+        self.add_job(Job("setup", steps=steps, outputs=outputs))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", help="Path to configuration file", required=True)
+    parser.add_argument(
+        "--dep-tree", help="Path to dependency tree file.", required=True
+    )
+    parser.add_argument(
+        "--output",
+        help="Path to output directory. Workflow files will be created/overwritten there.",
+        required=True,
+    )
+    args = parser.parse_args()
+
+    with open(args.config, "r") as f:
+        config: dict = yaml.safe_load(f)
+
+    with open(args.dep_tree, "r") as f:
+        dep_tree: dict = yaml.safe_load(f)
+
+    for name in config.keys():
+        wf = Workflow(name=name, wf_type=config[name]["type"])
+        wf.generate_inputs(dep_tree)
+        wf.generate_setup_job(dep_tree, config[name])
+        if config[name].get("python_qa", False):
+            wf.add_python_qa_job()
+        wf.generate_package_jobs(dep_tree)
+        print(yaml.dump(wf, indent=2, sort_keys=False, default_flow_style=False))
+        print("=" * 10)
+        with open(PurePath(args.output, name + ".yml"), "w") as f:
+            yaml.dump(
+                wf,
+                stream=f,
+                indent=2,
+                sort_keys=False,
+                default_flow_style=False,
+                width=float("inf"),
+            )
+
+
+# wf spec inputs
+# config var
+
+
+if __name__ == "__main__":
+    main()

--- a/setup_downstream_ci.py
+++ b/setup_downstream_ci.py
@@ -50,7 +50,7 @@ ci_config: dict = yaml.safe_load(os.getenv("CONFIG", ""))
 python_versions = yaml.safe_load(os.getenv("PYTHON_VERSIONS", ""))
 python_jobs = yaml.safe_load(os.getenv("PYTHON_JOBS", ""))
 matrix = yaml.safe_load(os.getenv("MATRIX", ""))
-optional_matrix = yaml.safe_load(os.getenv("OPTIONAL_MATRIX", ""))
+optional_matrix = yaml.safe_load(os.getenv("OPTIONAL_MATRIX", "")) or {}
 skip_jobs = os.getenv("SKIP_MATRIX_JOBS", "").splitlines()
 token = os.getenv("TOKEN", "")
 trigger_ref_name = os.getenv("DISPATCH_REF_NAME") or os.getenv("GITHUB_REF_NAME", "")
@@ -143,7 +143,7 @@ for owner_repo, val in ci_config.items():
     matrices[repo] = copy.deepcopy(matrix)
 
     for opt in optional_matrix.get("name", []):
-        if opt in val.get("optional_matrix"):
+        if val.get("optional_matrix", []) and opt in val.get("optional_matrix", []):
             matrices[repo]["name"].append(opt)
             matrices[repo]["include"].extend(
                 [d for d in optional_matrix.get("include") if d["name"] == opt]
@@ -177,7 +177,7 @@ print(yaml.dump(matrices, sort_keys=False))
 
 
 with open("dependency_tree.yml", "r") as f:
-    dep_tree = list(yaml.safe_load_all(f))
+    dep_tree = yaml.safe_load(f)
 
 build_package_dep_tree = {}
 build_package_hpc_dep_tree = {}

--- a/setup_downstream_ci.py
+++ b/setup_downstream_ci.py
@@ -36,7 +36,6 @@ Outputs:
             build-package(-hpc)) and `config_path` (build config file path).
 """
 
-
 import copy
 import json
 import os
@@ -136,7 +135,7 @@ for owner_repo, val in ci_config.items():
         matrices[repo]["include"][index]["owner_repo_ref"] = f"{owner}/{repo}@{ref}"
         matrices[repo]["include"][index]["config_path"] = path
 
-    if val.get("python", ""):
+    if val.get("python", False) is True:
         matrices[repo]["python_version"] = python_versions
         if python_jobs:
             matrices[repo]["name"] = [


### PR DESCRIPTION
Adds a script to generate downstream workflows dynamically. This script is used to generate the workflows by a workflow on push.
Only update of dependency tree is needed in order to add a new package to downstream-ci. 
Moves configuration of the workflows themselves (mainly the matrix) to a separate file. 
Updates the setup script accordingly, e.g. to handle the optional matrix.