### PR TITLE
Add GH PAT only for private workflows

### DIFF
--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -643,7 +643,6 @@ jobs:
         build_dependencies: |-
           ${{ needs.setup.outputs.fckit }}
           ${{ needs.setup.outputs.eckit }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
   cfgrib:
@@ -670,13 +669,11 @@ jobs:
         build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
         build_config: ${{ matrix.config_path }}
         build_dependencies: ${{ needs.setup.outputs.eccodes }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
     - uses: ecmwf-actions/reusable-workflows/ci-python@v2
       with:
         lib_path: ${{ steps.build-deps.outputs.lib_path }}
         bin_paths: ${{ steps.build-deps.outputs.bin_paths }}
         python_dependencies: ${{ needs.setup.outputs.eccodes-python }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         requirements_path: ci/requirements-tests.in
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
@@ -717,7 +714,6 @@ jobs:
           ${{ needs.setup.outputs.eccodes }}
           ${{ needs.setup.outputs.odc }}
           ${{ needs.setup.outputs.eckit }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
     - uses: ecmwf-actions/reusable-workflows/ci-python@v2
       with:
         lib_path: ${{ steps.build-deps.outputs.lib_path }}
@@ -732,7 +728,6 @@ jobs:
           ${{ needs.setup.outputs.earthkit-geo }}
           ${{ needs.setup.outputs.earthkit-meteo }}
           ${{ needs.setup.outputs.earthkit-regrid }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         requirements_path: tests/downstream-ci-requirements.txt
         test_cmd: '_EKD_DIR=$(pwd) && cd .. && python -m pytest ${_EKD_DIR} -vv --cov=. --cov-report=html && cd -
 
@@ -772,7 +767,6 @@ jobs:
           ${{ needs.setup.outputs.eccodes }}
           ${{ needs.setup.outputs.odc }}
           ${{ needs.setup.outputs.eckit }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
     - uses: ecmwf-actions/reusable-workflows/ci-python@v2
       with:
         lib_path: ${{ steps.build-deps.outputs.lib_path }}
@@ -783,7 +777,6 @@ jobs:
           ${{ needs.setup.outputs.pdbufr }}
           ${{ needs.setup.outputs.eccodes-python }}
           ${{ needs.setup.outputs.pyodc }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         requirements_path: tests/downstream-ci-requirements.txt
         test_cmd: |
           python -m pytest -vv -m 'not notebook and not no_cache_init' --cov=. --cov-report=xml
@@ -810,7 +803,6 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         checkout: true
         python_dependencies: ''
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         requirements_path: tests/downstream-ci-requirements.txt
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
@@ -832,7 +824,6 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         checkout: true
         python_dependencies: ''
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         requirements_path: tests/downstream-ci-requirements.txt
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
@@ -854,7 +845,6 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         checkout: true
         python_dependencies: ''
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         requirements_path: tests/downstream-ci-requirements.txt
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
@@ -877,7 +867,6 @@ jobs:
         build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
         build_config: ${{ matrix.config_path }}
         build_dependencies: ''
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
   eccodes-python:
@@ -903,13 +892,11 @@ jobs:
         build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
         build_config: ${{ matrix.config_path }}
         build_dependencies: ${{ needs.setup.outputs.eccodes }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
     - uses: ecmwf-actions/reusable-workflows/ci-python@v2
       with:
         lib_path: ${{ steps.build-deps.outputs.lib_path }}
         bin_paths: ${{ steps.build-deps.outputs.bin_paths }}
         python_dependencies: ''
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
   ecflow:
@@ -931,7 +918,6 @@ jobs:
         build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
         build_config: ${{ matrix.config_path }}
         build_dependencies: ''
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
         python_version: '3.10'
@@ -955,7 +941,6 @@ jobs:
         build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
         build_config: ${{ matrix.config_path }}
         build_dependencies: ${{ needs.setup.outputs.eckit }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
   eckit:
@@ -977,7 +962,6 @@ jobs:
         build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
         build_config: ${{ matrix.config_path }}
         build_dependencies: ''
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
   fckit:
@@ -1000,7 +984,6 @@ jobs:
         build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
         build_config: ${{ matrix.config_path }}
         build_dependencies: ${{ needs.setup.outputs.eckit }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
   fdb:
@@ -1028,7 +1011,6 @@ jobs:
           ${{ needs.setup.outputs.metkit }}
           ${{ needs.setup.outputs.eccodes }}
           ${{ needs.setup.outputs.eckit }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
   findlibs:
@@ -1049,7 +1031,6 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         checkout: true
         python_dependencies: ''
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         requirements_path: tests/downstream-ci-requirements.txt
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
@@ -1076,7 +1057,6 @@ jobs:
         build_dependencies: |-
           ${{ needs.setup.outputs.fckit }}
           ${{ needs.setup.outputs.eckit }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
   kronos:
@@ -1098,7 +1078,6 @@ jobs:
         build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
         build_config: ${{ matrix.config_path }}
         build_dependencies: ''
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
   metkit:
@@ -1124,7 +1103,6 @@ jobs:
         build_dependencies: |-
           ${{ needs.setup.outputs.eccodes }}
           ${{ needs.setup.outputs.eckit }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
   mir:
@@ -1154,7 +1132,6 @@ jobs:
           ${{ needs.setup.outputs.fckit }}
           ${{ needs.setup.outputs.eckit }}
           ${{ needs.setup.outputs.eccodes }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
   multio:
@@ -1191,7 +1168,6 @@ jobs:
           ${{ needs.setup.outputs.fckit }}
           ${{ needs.setup.outputs.eckit }}
           ${{ needs.setup.outputs.eccodes }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
   multiurl:
@@ -1212,7 +1188,6 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         checkout: true
         python_dependencies: ''
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
   odc:
@@ -1235,7 +1210,6 @@ jobs:
         build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
         build_config: ${{ matrix.config_path }}
         build_dependencies: ${{ needs.setup.outputs.eckit }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
   pdbufr:
@@ -1262,13 +1236,11 @@ jobs:
         build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
         build_config: ${{ matrix.config_path }}
         build_dependencies: ${{ needs.setup.outputs.eccodes }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
     - uses: ecmwf-actions/reusable-workflows/ci-python@v2
       with:
         lib_path: ${{ steps.build-deps.outputs.lib_path }}
         bin_paths: ${{ steps.build-deps.outputs.bin_paths }}
         python_dependencies: ${{ needs.setup.outputs.eccodes-python }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         requirements_path: tests/downstream-ci-requirements.txt
         test_cmd: |
           python -m pytest --cov=./ --cov-report=xml -k 'not test_notebooks'
@@ -1300,7 +1272,6 @@ jobs:
           ${{ needs.setup.outputs.atlas }}
           ${{ needs.setup.outputs.fckit }}
           ${{ needs.setup.outputs.eckit }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload }}
   pyfdb:
@@ -1336,14 +1307,12 @@ jobs:
           ${{ needs.setup.outputs.metkit }}
           ${{ needs.setup.outputs.eccodes }}
           ${{ needs.setup.outputs.eckit }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
     - run: mkdir -p data/fdb
     - uses: ecmwf-actions/reusable-workflows/ci-python@v2
       with:
         lib_path: ${{ steps.build-deps.outputs.lib_path }}
         bin_paths: ${{ steps.build-deps.outputs.bin_paths }}
         python_dependencies: ''
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
   pyodc:
@@ -1372,13 +1341,11 @@ jobs:
         build_dependencies: |-
           ${{ needs.setup.outputs.odc }}
           ${{ needs.setup.outputs.eckit }}
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
     - uses: ecmwf-actions/reusable-workflows/ci-python@v2
       with:
         lib_path: ${{ steps.build-deps.outputs.lib_path }}
         bin_paths: ${{ steps.build-deps.outputs.bin_paths }}
         python_dependencies: ''
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
   skinnywms:
@@ -1399,7 +1366,6 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         checkout: true
         python_dependencies: ''
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
   thermofeel:
@@ -1420,7 +1386,6 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         checkout: true
         python_dependencies: ''
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
   troika:
@@ -1441,7 +1406,6 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         checkout: true
         python_dependencies: ''
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         test_cmd: |
           pytest --cov=./ --cov-report=xml --basetemp=$RUNNER_TEMP/pytest_tmp
           python -m coverage report
@@ -1465,6 +1429,5 @@ jobs:
         repository: ${{ matrix.owner_repo_ref }}
         checkout: true
         python_dependencies: ''
-        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}

--- a/generate-workflows.py
+++ b/generate-workflows.py
@@ -336,7 +336,6 @@ class Workflow:
                             ),
                             "build_config": "${{ matrix.config_path }}",
                             "build_dependencies": "\n".join(cmake_deps),
-                            "github_token": "${{ secrets.GH_REPO_READ_TOKEN }}",
                         },
                     }
                     if not self.private:
@@ -347,6 +346,8 @@ class Workflow:
                             "${{ needs.setup.outputs.trigger_repo "
                             "== github.job && inputs.codecov_upload }}"
                         )
+                    else:
+                        s["with"]["github_token"] = "${{ secrets.GH_REPO_READ_TOKEN }}"
                     if build_package_python:
                         s["with"]["python_version"] = build_package_python
                     steps.append(s)
@@ -369,9 +370,10 @@ class Workflow:
                                 ),
                                 "build_config": "${{ matrix.config_path }}",
                                 "build_dependencies": "\n".join(cmake_deps),
-                                "github_token": "${{ secrets.GH_REPO_READ_TOKEN }}",
                             },
                         }
+                        if self.private:
+                            s["with"]["github_token"] = "${{ secrets.GH_REPO_READ_TOKEN }}"
                         if build_package_python:
                             s["with"]["python_version"] = build_package_python
                         steps.append(s)
@@ -387,7 +389,6 @@ class Workflow:
                                     "${{ steps.build-deps.outputs.bin_paths }}"
                                 ),
                                 "python_dependencies": "\n".join(python_deps),
-                                "github_token": "${{ secrets.GH_REPO_READ_TOKEN }}",
                             },
                         }
                         if pkg_conf.get("requirements_path"):
@@ -408,6 +409,8 @@ class Workflow:
                             ci_python_step["with"][
                                 "codecov_token"
                             ] = "${{ secrets.CODECOV_UPLOAD_TOKEN }}"
+                        else:
+                            ci_python_step["with"]["github_token"] = "${{ secrets.GH_REPO_READ_TOKEN }}"
                         steps.append(ci_python_step)
                     else:
                         # pure python package
@@ -417,7 +420,6 @@ class Workflow:
                                 "repository": "${{ matrix.owner_repo_ref }}",
                                 "checkout": True,
                                 "python_dependencies": "\n".join(python_deps),
-                                "github_token": "${{ secrets.GH_REPO_READ_TOKEN }}",
                             },
                         }
                         if pkg_conf.get("requirements_path"):
@@ -438,6 +440,8 @@ class Workflow:
                             ci_python_step["with"][
                                 "codecov_token"
                             ] = "${{ secrets.CODECOV_UPLOAD_TOKEN }}"
+                        else:
+                            ci_python_step["with"]["github_token"] = "${{ secrets.GH_REPO_READ_TOKEN }}"
                         steps.append(ci_python_step)
             if self.wf_type == "build-package-hpc":
                 runs_on = [


### PR DESCRIPTION
Reduce PAT usage. Actions use $GITHUB_TOKEN by default, and that's sufficient for public downstream CI. Private tree is still using the PAT.