### PR TITLE
Concurrency

### DIFF
--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -134,7 +134,7 @@ name: downstream-ci-hpc
         required: false
         type: string
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-downstream-ci-hpc
   cancel-in-progress: true
 jobs:
   setup:

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -1795,3 +1795,6 @@ jobs:
         build_config: ${{ matrix.config_path }}
         dependencies: ''
         python_dependencies: ''
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: 'true'

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -133,6 +133,9 @@ name: downstream-ci-hpc
         description: List of matrix jobs to be skipped.
         required: false
         type: string
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: 'true'
 jobs:
   setup:
     name: setup
@@ -1795,6 +1798,3 @@ jobs:
         build_config: ${{ matrix.config_path }}
         dependencies: ''
         python_dependencies: ''
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: 'true'

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -135,7 +135,7 @@ name: downstream-ci-hpc
         type: string
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: 'true'
+  cancel-in-progress: true
 jobs:
   setup:
     name: setup

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -149,6 +149,9 @@ name: downstream-ci
         description: A list of paths to be skipped during formatting check.
         type: string
         required: false
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: 'true'
 jobs:
   setup:
     name: setup
@@ -1918,6 +1921,3 @@ jobs:
         python_dependencies: ''
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: 'true'

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -1918,3 +1918,6 @@ jobs:
         python_dependencies: ''
         codecov_upload: ${{ needs.setup.outputs.trigger_repo == github.job && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: 'true'

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -150,7 +150,7 @@ name: downstream-ci
         type: string
         required: false
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-downstream-ci
   cancel-in-progress: true
 jobs:
   setup:

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -151,7 +151,7 @@ name: downstream-ci
         required: false
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: 'true'
+  cancel-in-progress: true
 jobs:
   setup:
     name: setup

--- a/generate-workflows.py
+++ b/generate-workflows.py
@@ -127,10 +127,8 @@ class Workflow:
 
     def concurrency(self) -> object:
         c = {
-            "concurrency": {
-                "group": "${{ github.workflow }}-${{ github.ref }}",
-                "cancel-in-progress": "true",
-            },
+            "group": "${{ github.workflow }}-${{ github.ref }}",
+            "cancel-in-progress": "true",
         }
 
         return c
@@ -140,7 +138,7 @@ class Workflow:
             "name": self.name,
             "on": {"workflow_call": {"inputs": self.inputs}},
             "jobs": self.jobs,
-            self.concurrency(),
+            "concurrency": self.concurrency(),
         }
         if self.private:
             dispatch_type = (

--- a/generate-workflows.py
+++ b/generate-workflows.py
@@ -137,8 +137,8 @@ class Workflow:
         d = {
             "name": self.name,
             "on": {"workflow_call": {"inputs": self.inputs}},
-            "jobs": self.jobs,
             "concurrency": self.concurrency(),
+            "jobs": self.jobs,
         }
         if self.private:
             dispatch_type = (

--- a/generate-workflows.py
+++ b/generate-workflows.py
@@ -125,6 +125,8 @@ class Workflow:
             if is_input(package, dep_tree, self.name, self.private):
                 self.inputs[package] = {"required": False, "type": "string"}
 
+    # this setting ensures that multiple pushes to the same branch of a repo
+    # will result in all but the latest ci workflows being cancelled
     def concurrency(self) -> object:
         c = {
             "group": "${{ github.workflow }}-${{ github.ref }}-" + self.name,

--- a/generate-workflows.py
+++ b/generate-workflows.py
@@ -128,7 +128,7 @@ class Workflow:
     def concurrency(self) -> object:
         c = {
             "group": "${{ github.workflow }}-${{ github.ref }}",
-            "cancel-in-progress": "true",
+            "cancel-in-progress": True,
         }
 
         return c

--- a/generate-workflows.py
+++ b/generate-workflows.py
@@ -127,7 +127,7 @@ class Workflow:
 
     def concurrency(self) -> object:
         c = {
-            "group": "${{ github.workflow }}-${{ github.ref }}",
+            "group": "${{ github.workflow }}-${{ github.ref }}-" + self.name,
             "cancel-in-progress": True,
         }
 

--- a/generate-workflows.py
+++ b/generate-workflows.py
@@ -125,11 +125,22 @@ class Workflow:
             if is_input(package, dep_tree, self.name, self.private):
                 self.inputs[package] = {"required": False, "type": "string"}
 
+    def concurrency(self) -> object:
+        c = {
+            "concurrency": {
+                "group": "${{ github.workflow }}-${{ github.ref }}",
+                "cancel-in-progress": "true",
+            },
+        }
+
+        return c
+    
     def __getstate__(self) -> object:
         d = {
             "name": self.name,
             "on": {"workflow_call": {"inputs": self.inputs}},
             "jobs": self.jobs,
+            self.concurrency(),
         }
         if self.private:
             dispatch_type = (


### PR DESCRIPTION
This ensures that multiple pushes to the same branch of a repo will result in all but the latest ci workflows being cancelled. This should help free up runner resources and save time.