### PR TITLE
Fix/remove anemoi datasets from upstream

### DIFF
--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -904,19 +904,8 @@ jobs:
   anemoi-datasets:
     name: anemoi-datasets
     needs:
-    - earthkit-data
-    - cfgrib
-    - multiurl
-    - pdbufr
-    - eccodes-python
-    - eccodes
-    - pyodc
-    - odc
-    - eckit
-    - earthkit-geo
-    - earthkit-meteo
     - setup
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.anemoi-datasets_matrix && (needs.setup.outputs.earthkit-data || needs.setup.outputs.cfgrib || needs.setup.outputs.multiurl || needs.setup.outputs.pdbufr || needs.setup.outputs.eccodes-python || needs.setup.outputs.eccodes || needs.setup.outputs.pyodc || needs.setup.outputs.odc || needs.setup.outputs.eckit || needs.setup.outputs.earthkit-geo || needs.setup.outputs.earthkit-meteo || needs.setup.outputs.anemoi-datasets) }}
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.anemoi-datasets_matrix && (needs.setup.outputs.anemoi-datasets) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.anemoi-datasets_matrix) }}
@@ -934,19 +923,8 @@ jobs:
         troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
-        dependencies: |-
-          ${{ needs.setup.outputs.eccodes }}
-          ${{ needs.setup.outputs.odc }}
-          ${{ needs.setup.outputs.eckit }}
-        python_dependencies: |-
-          ${{ needs.setup.outputs.earthkit-data }}
-          ${{ needs.setup.outputs.cfgrib }}
-          ${{ needs.setup.outputs.multiurl }}
-          ${{ needs.setup.outputs.pdbufr }}
-          ${{ needs.setup.outputs.eccodes-python }}
-          ${{ needs.setup.outputs.pyodc }}
-          ${{ needs.setup.outputs.earthkit-geo }}
-          ${{ needs.setup.outputs.earthkit-meteo }}
+        dependencies: ''
+        python_dependencies: ''
         python_toml_opt_dep_sections: all,tests
   anemoi-utils:
     name: anemoi-utils
@@ -977,20 +955,9 @@ jobs:
     name: anemoi-graphs
     needs:
     - anemoi-datasets
-    - earthkit-data
-    - cfgrib
-    - multiurl
-    - pdbufr
-    - eccodes-python
-    - eccodes
-    - pyodc
-    - odc
-    - eckit
-    - earthkit-geo
-    - earthkit-meteo
     - anemoi-utils
     - setup
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.anemoi-graphs_matrix && (needs.setup.outputs.anemoi-datasets || needs.setup.outputs.earthkit-data || needs.setup.outputs.cfgrib || needs.setup.outputs.multiurl || needs.setup.outputs.pdbufr || needs.setup.outputs.eccodes-python || needs.setup.outputs.eccodes || needs.setup.outputs.pyodc || needs.setup.outputs.odc || needs.setup.outputs.eckit || needs.setup.outputs.earthkit-geo || needs.setup.outputs.earthkit-meteo || needs.setup.outputs.anemoi-utils || needs.setup.outputs.anemoi-graphs) }}
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.anemoi-graphs_matrix && (needs.setup.outputs.anemoi-datasets || needs.setup.outputs.anemoi-utils || needs.setup.outputs.anemoi-graphs) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.anemoi-graphs_matrix) }}
@@ -1008,20 +975,9 @@ jobs:
         troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
-        dependencies: |-
-          ${{ needs.setup.outputs.eccodes }}
-          ${{ needs.setup.outputs.odc }}
-          ${{ needs.setup.outputs.eckit }}
+        dependencies: ''
         python_dependencies: |-
           ${{ needs.setup.outputs.anemoi-datasets }}
-          ${{ needs.setup.outputs.earthkit-data }}
-          ${{ needs.setup.outputs.cfgrib }}
-          ${{ needs.setup.outputs.multiurl }}
-          ${{ needs.setup.outputs.pdbufr }}
-          ${{ needs.setup.outputs.eccodes-python }}
-          ${{ needs.setup.outputs.pyodc }}
-          ${{ needs.setup.outputs.earthkit-geo }}
-          ${{ needs.setup.outputs.earthkit-meteo }}
           ${{ needs.setup.outputs.anemoi-utils }}
         python_toml_opt_dep_sections: all,tests
   anemoi-models:
@@ -1056,20 +1012,9 @@ jobs:
     - anemoi-models
     - anemoi-graphs
     - anemoi-datasets
-    - earthkit-data
-    - cfgrib
-    - multiurl
-    - pdbufr
-    - eccodes-python
-    - eccodes
-    - pyodc
-    - odc
-    - eckit
-    - earthkit-geo
-    - earthkit-meteo
     - anemoi-utils
     - setup
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.anemoi-training_matrix && (needs.setup.outputs.anemoi-models || needs.setup.outputs.anemoi-graphs || needs.setup.outputs.anemoi-datasets || needs.setup.outputs.earthkit-data || needs.setup.outputs.cfgrib || needs.setup.outputs.multiurl || needs.setup.outputs.pdbufr || needs.setup.outputs.eccodes-python || needs.setup.outputs.eccodes || needs.setup.outputs.pyodc || needs.setup.outputs.odc || needs.setup.outputs.eckit || needs.setup.outputs.earthkit-geo || needs.setup.outputs.earthkit-meteo || needs.setup.outputs.anemoi-utils || needs.setup.outputs.anemoi-training) }}
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.anemoi-training_matrix && (needs.setup.outputs.anemoi-models || needs.setup.outputs.anemoi-graphs || needs.setup.outputs.anemoi-datasets || needs.setup.outputs.anemoi-utils || needs.setup.outputs.anemoi-training) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.anemoi-training_matrix) }}
@@ -1087,22 +1032,11 @@ jobs:
         troika_user: ${{ secrets.HPC_CI_SSH_USER }}
         repository: ${{ matrix.owner_repo_ref }}
         build_config: ${{ matrix.config_path }}
-        dependencies: |-
-          ${{ needs.setup.outputs.eccodes }}
-          ${{ needs.setup.outputs.odc }}
-          ${{ needs.setup.outputs.eckit }}
+        dependencies: ''
         python_dependencies: |-
           ${{ needs.setup.outputs.anemoi-models }}
           ${{ needs.setup.outputs.anemoi-graphs }}
           ${{ needs.setup.outputs.anemoi-datasets }}
-          ${{ needs.setup.outputs.earthkit-data }}
-          ${{ needs.setup.outputs.cfgrib }}
-          ${{ needs.setup.outputs.multiurl }}
-          ${{ needs.setup.outputs.pdbufr }}
-          ${{ needs.setup.outputs.eccodes-python }}
-          ${{ needs.setup.outputs.pyodc }}
-          ${{ needs.setup.outputs.earthkit-geo }}
-          ${{ needs.setup.outputs.earthkit-meteo }}
           ${{ needs.setup.outputs.anemoi-utils }}
         python_toml_opt_dep_sections: all,tests
   anemoi-inference:

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -1041,20 +1041,9 @@ jobs:
   anemoi-datasets:
     name: anemoi-datasets
     needs:
-    - earthkit-data
-    - cfgrib
-    - multiurl
-    - pdbufr
-    - eccodes-python
-    - eccodes
-    - pyodc
-    - odc
-    - eckit
-    - earthkit-geo
-    - earthkit-meteo
     - setup
     - python-qa
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.anemoi-datasets_matrix && (needs.setup.outputs.earthkit-data || needs.setup.outputs.cfgrib || needs.setup.outputs.multiurl || needs.setup.outputs.pdbufr || needs.setup.outputs.eccodes-python || needs.setup.outputs.eccodes || needs.setup.outputs.pyodc || needs.setup.outputs.odc || needs.setup.outputs.eckit || needs.setup.outputs.earthkit-geo || needs.setup.outputs.earthkit-meteo || needs.setup.outputs.anemoi-datasets) }}
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.anemoi-datasets_matrix && (needs.setup.outputs.anemoi-datasets) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.anemoi-datasets_matrix) }}
@@ -1063,31 +1052,11 @@ jobs:
       RUNNER_TYPE: self-hosted
     runs-on: ${{ matrix.labels }}
     steps:
-    - name: Build dependencies
-      id: build-deps
-      uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-      with:
-        repository: ${{ matrix.owner_repo_ref }}
-        codecov_upload: false
-        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
-        build_config: ${{ matrix.config_path }}
-        build_dependencies: |-
-          ${{ needs.setup.outputs.eccodes }}
-          ${{ needs.setup.outputs.odc }}
-          ${{ needs.setup.outputs.eckit }}
     - uses: ecmwf-actions/reusable-workflows/ci-python@v2
       with:
-        lib_path: ${{ steps.build-deps.outputs.lib_path }}
-        bin_paths: ${{ steps.build-deps.outputs.bin_paths }}
-        python_dependencies: |-
-          ${{ needs.setup.outputs.earthkit-data }}
-          ${{ needs.setup.outputs.cfgrib }}
-          ${{ needs.setup.outputs.multiurl }}
-          ${{ needs.setup.outputs.pdbufr }}
-          ${{ needs.setup.outputs.eccodes-python }}
-          ${{ needs.setup.outputs.pyodc }}
-          ${{ needs.setup.outputs.earthkit-geo }}
-          ${{ needs.setup.outputs.earthkit-meteo }}
+        repository: ${{ matrix.owner_repo_ref }}
+        checkout: true
+        python_dependencies: ''
         toml_opt_dep_sections: all,tests
         test_cmd: |
           python -m pytest -vv -m 'not notebook and not no_cache_init' --cov=. --cov-report=xml
@@ -1122,21 +1091,10 @@ jobs:
     name: anemoi-graphs
     needs:
     - anemoi-datasets
-    - earthkit-data
-    - cfgrib
-    - multiurl
-    - pdbufr
-    - eccodes-python
-    - eccodes
-    - pyodc
-    - odc
-    - eckit
-    - earthkit-geo
-    - earthkit-meteo
     - anemoi-utils
     - setup
     - python-qa
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.anemoi-graphs_matrix && (needs.setup.outputs.anemoi-datasets || needs.setup.outputs.earthkit-data || needs.setup.outputs.cfgrib || needs.setup.outputs.multiurl || needs.setup.outputs.pdbufr || needs.setup.outputs.eccodes-python || needs.setup.outputs.eccodes || needs.setup.outputs.pyodc || needs.setup.outputs.odc || needs.setup.outputs.eckit || needs.setup.outputs.earthkit-geo || needs.setup.outputs.earthkit-meteo || needs.setup.outputs.anemoi-utils || needs.setup.outputs.anemoi-graphs) }}
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.anemoi-graphs_matrix && (needs.setup.outputs.anemoi-datasets || needs.setup.outputs.anemoi-utils || needs.setup.outputs.anemoi-graphs) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.anemoi-graphs_matrix) }}
@@ -1144,32 +1102,12 @@ jobs:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
     runs-on: ${{ matrix.labels }}
     steps:
-    - name: Build dependencies
-      id: build-deps
-      uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-      with:
-        repository: ${{ matrix.owner_repo_ref }}
-        codecov_upload: false
-        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
-        build_config: ${{ matrix.config_path }}
-        build_dependencies: |-
-          ${{ needs.setup.outputs.eccodes }}
-          ${{ needs.setup.outputs.odc }}
-          ${{ needs.setup.outputs.eckit }}
     - uses: ecmwf-actions/reusable-workflows/ci-python@v2
       with:
-        lib_path: ${{ steps.build-deps.outputs.lib_path }}
-        bin_paths: ${{ steps.build-deps.outputs.bin_paths }}
+        repository: ${{ matrix.owner_repo_ref }}
+        checkout: true
         python_dependencies: |-
           ${{ needs.setup.outputs.anemoi-datasets }}
-          ${{ needs.setup.outputs.earthkit-data }}
-          ${{ needs.setup.outputs.cfgrib }}
-          ${{ needs.setup.outputs.multiurl }}
-          ${{ needs.setup.outputs.pdbufr }}
-          ${{ needs.setup.outputs.eccodes-python }}
-          ${{ needs.setup.outputs.pyodc }}
-          ${{ needs.setup.outputs.earthkit-geo }}
-          ${{ needs.setup.outputs.earthkit-meteo }}
           ${{ needs.setup.outputs.anemoi-utils }}
         toml_opt_dep_sections: all,tests
         test_cmd: |
@@ -1208,21 +1146,10 @@ jobs:
     - anemoi-models
     - anemoi-graphs
     - anemoi-datasets
-    - earthkit-data
-    - cfgrib
-    - multiurl
-    - pdbufr
-    - eccodes-python
-    - eccodes
-    - pyodc
-    - odc
-    - eckit
-    - earthkit-geo
-    - earthkit-meteo
     - anemoi-utils
     - setup
     - python-qa
-    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.anemoi-training_matrix && (needs.setup.outputs.anemoi-models || needs.setup.outputs.anemoi-graphs || needs.setup.outputs.anemoi-datasets || needs.setup.outputs.earthkit-data || needs.setup.outputs.cfgrib || needs.setup.outputs.multiurl || needs.setup.outputs.pdbufr || needs.setup.outputs.eccodes-python || needs.setup.outputs.eccodes || needs.setup.outputs.pyodc || needs.setup.outputs.odc || needs.setup.outputs.eckit || needs.setup.outputs.earthkit-geo || needs.setup.outputs.earthkit-meteo || needs.setup.outputs.anemoi-utils || needs.setup.outputs.anemoi-training) }}
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.anemoi-training_matrix && (needs.setup.outputs.anemoi-models || needs.setup.outputs.anemoi-graphs || needs.setup.outputs.anemoi-datasets || needs.setup.outputs.anemoi-utils || needs.setup.outputs.anemoi-training) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.anemoi-training_matrix) }}
@@ -1230,34 +1157,14 @@ jobs:
       DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
     runs-on: ${{ matrix.labels }}
     steps:
-    - name: Build dependencies
-      id: build-deps
-      uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
-      with:
-        repository: ${{ matrix.owner_repo_ref }}
-        codecov_upload: false
-        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
-        build_config: ${{ matrix.config_path }}
-        build_dependencies: |-
-          ${{ needs.setup.outputs.eccodes }}
-          ${{ needs.setup.outputs.odc }}
-          ${{ needs.setup.outputs.eckit }}
     - uses: ecmwf-actions/reusable-workflows/ci-python@v2
       with:
-        lib_path: ${{ steps.build-deps.outputs.lib_path }}
-        bin_paths: ${{ steps.build-deps.outputs.bin_paths }}
+        repository: ${{ matrix.owner_repo_ref }}
+        checkout: true
         python_dependencies: |-
           ${{ needs.setup.outputs.anemoi-models }}
           ${{ needs.setup.outputs.anemoi-graphs }}
           ${{ needs.setup.outputs.anemoi-datasets }}
-          ${{ needs.setup.outputs.earthkit-data }}
-          ${{ needs.setup.outputs.cfgrib }}
-          ${{ needs.setup.outputs.multiurl }}
-          ${{ needs.setup.outputs.pdbufr }}
-          ${{ needs.setup.outputs.eccodes-python }}
-          ${{ needs.setup.outputs.pyodc }}
-          ${{ needs.setup.outputs.earthkit-geo }}
-          ${{ needs.setup.outputs.earthkit-meteo }}
           ${{ needs.setup.outputs.anemoi-utils }}
         toml_opt_dep_sections: all,tests
         test_cmd: |

--- a/dependency_tree.yml
+++ b/dependency_tree.yml
@@ -86,10 +86,6 @@ anemoi-datasets:
   type: python
   master_branch: main
   toml_opt_dep_sections: all,tests
-  deps:
-    - earthkit-data
-    - earthkit-geo
-    - earthkit-meteo
   downstream-ci:
     env:
       RUNNER_TYPE: "self-hosted"


### PR DESCRIPTION
We want to cut the dependency tree between other (operational) ECMWF packages for now as Anemoi is still heavily under development and might lead to blockers on upstream dependency merge requests.

This PR removes the upstream dependencies from Anemoi-datasets in the dependency tree. As a result the workflows for other anemoi packages should not be triggered anymore for any of the upstream dependencies of Anemoi-datasets.